### PR TITLE
docs: Add missing steps to running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 ## Running project locally
 
-To run the website locally on your own machine, you must first create a `.env`
-file for each project. For example, for Quansight Consulting LLC, create
-`apps/consulting/.env`:
+Prerequisites: Node and npm.
+
+To run the website locally on your own machine, you must first clone this git
+repo, `cd` into the repo, then run `npm install`.
+
+This repo contains two projects (websites): Consulting and Labs. You must create
+a `.env` file for each project that you want to develop locally. For example,
+for Quansight Consulting LLC, create `apps/consulting/.env`:
 
 ```
 STORYBLOK_API_URL=https://gapi.storyblok.com/v1/api

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Storyblok panel. On the localhost the app will automatically reload if you
 change any of the source files, in the Storyblok panel you need to refresh the
 page manually.
 
+Important: whenever the website's dependencies change or are updated, the lock file
+`package-lock.json` will be updated. Whenever `package-lock.json` is updated,
+you should re-run `npm install` (or `npm cli`), so that your local environment's
+dependencies will match the production environment.
+
 ## Adding new components
 
 1. Create the component with its schema in Storyblok components.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Running project locally
 
-Add the [consulting environment variables](https://vercel.com/quansight/quansight-consulting/settings/environment-variables) or the [labs environment variables](https://vercel.com/quansight/quansight-labs/settings/environment-variables) to your shell, depending on which one you want to work on.
+Add the [consulting environment variables](https://vercel.com/quansight/quansight-consulting/settings/environment-variables) or the [labs environment variables](https://vercel.com/quansight/quansight-labs/settings/environment-variables) to your shell, depending on which one you want to work on:
 
 ```sh
-export STORYBLOK_API_URL={value from Vercel admin above}
-export STORYBLOK_PREVIEW_TOKEN={value from Vercel admin above}
+export STORYBLOK_API_URL={value from Vercel admin}
+export STORYBLOK_PREVIEW_TOKEN={value from Vercel admin}
 ```
 
 Run `npm run start:consulting` or `npm run start:labs` to start a corresponding dev server. Navigate to http://localhost:4200/ or use localhost preview in Storyblok panel. On the localhost the app will automatically reload if you change any of the source files, in the Storyblok panel you need to refresh the page manually.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 ## Running project locally
 
+Add the [consulting environment variables](https://vercel.com/quansight/quansight-consulting/settings/environment-variables) or the [labs environment variables](https://vercel.com/quansight/quansight-labs/settings/environment-variables) to your shell, depending on which one you want to work on.
+
+```sh
+export STORYBLOK_API_URL={value from Vercel admin above}
+export STORYBLOK_PREVIEW_TOKEN={value from Vercel admin above}
+```
+
 Run `npm run start:consulting` or `npm run start:labs` to start a corresponding dev server. Navigate to http://localhost:4200/ or use localhost preview in Storyblok panel. On the localhost the app will automatically reload if you change any of the source files, in the Storyblok panel you need to refresh the page manually.
 
 ## Adding new components

--- a/README.md
+++ b/README.md
@@ -2,14 +2,32 @@
 
 ## Running project locally
 
-Add the [consulting environment variables](https://vercel.com/quansight/quansight-consulting/settings/environment-variables) or the [labs environment variables](https://vercel.com/quansight/quansight-labs/settings/environment-variables) to your shell, depending on which one you want to work on:
+To run the website locally on your own machine, you must first create a `.env`
+file for each project. For example, for Quansight Consulting LLC, create
+`apps/consulting/.env`:
 
-```sh
-export STORYBLOK_API_URL={value from Vercel admin}
-export STORYBLOK_PREVIEW_TOKEN={value from Vercel admin}
+```
+STORYBLOK_API_URL=https://gapi.storyblok.com/v1/api
+STORYBLOK_PREVIEW_TOKEN="Secret string that you must get from the Vercel admin portal (link is below)"
+DOMAIN=https://localhost:4200
+NEXT_PUBLIC_STORYBLOK_PREVIEW_TOKEN="Secret string that you must get from the Vercel admin portal (link is below)"
 ```
 
-Run `npm run start:consulting` or `npm run start:labs` to start a corresponding dev server. Navigate to http://localhost:4200/ or use localhost preview in Storyblok panel. On the localhost the app will automatically reload if you change any of the source files, in the Storyblok panel you need to refresh the page manually.
+There are two secret values that you must get from the Vercel admin:
+
+- [consulting environment
+  variables](https://vercel.com/quansight/quansight-consulting/settings/environment-variables)
+- [labs environment
+  variables](https://vercel.com/quansight/quansight-labs/settings/environment-variables)
+
+If the example .env file above does not match what you read in the Vercel admin,
+use what's in Vercel.
+
+Run `npm run start:consulting` or `npm run start:labs` to start a corresponding
+dev server. Navigate to http://localhost:4200/ or use localhost preview in
+Storyblok panel. On the localhost the app will automatically reload if you
+change any of the source files, in the Storyblok panel you need to refresh the
+page manually.
 
 ## Adding new components
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Running project locally
 
-Prerequisites: Node and npm.
+Prerequisites: [Node](https://nodejs.org/en/).
 
 To run the website locally on your own machine, you must first clone this git
 repo, `cd` into the repo, then run `npm install`.
@@ -29,7 +29,7 @@ If the example .env file above does not match what you read in the Vercel admin,
 use what's in Vercel.
 
 Run `npm run start:consulting` or `npm run start:labs` to start a corresponding
-dev server. Navigate to http://localhost:4200/ or use localhost preview in
+dev server. Navigate to <http://localhost:4200/> or use localhost preview in
 Storyblok panel. On the localhost the app will automatically reload if you
 change any of the source files, in the Storyblok panel you need to refresh the
 page manually.


### PR DESCRIPTION
The repo readme was missing instructions for running locally:

1. Cloning from GitHub
2. Installing via npm
3. Configuring environment (.env files)