### PR TITLE
Updating the blog workflow README and categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can fetch data from Storyblok directly using queries. To add the query:
 
 ## Technical blog workflow
 
-All of the labs blog posts are located inside `src/apps/labs/posts` and there all new posts should be added. Every post is a `.md` or `.mdx` file. The `posts` directory also contains `categories.json` file where there are all posts categories. The `categories.json` file is also used for displaying category filters on `/blog` page so after adding new category it will also be visible on that page.
+All of the labs blog posts are located inside `apps/labs/posts` and there all new posts should be added. Every post is a `.md` or `.mdx` file. The `posts` directory also contains `categories.json` file where there are all posts categories. The `categories.json` file is also used for displaying category filters on `/blog` page so after adding new category it will also be visible on that page.
 
 For more details about `mdx` please see:
 
@@ -42,8 +42,8 @@ Every post is structured with two main sections - the `meta` and `content` secti
 - `published` - Publishing date of the blog post. Used also for sorting posts by date.
 - `author` - Unique slug of the author (from Storyblok) usually looks like: `jon-doe`. Based on this property blog post page will display proper info about author (and image).
 - `category` - Array of categories for example `[Machine Learning]`. All categories should be the same as in the previously mentioned `categories.json` file. Important note: Categories are case sensitive.
-- `featuredImage` - Object with properties: `src` and `alt`. The `src` property is a path to featured image which is displayed on the posts list on the`/blog` page. The `alt` property is alternative text for the image. The image should be added to the `src/apps/labs/public/posts/<post-name>` directory, example: `src/apps/labs/public/posts/hello-world-post`. There is no need to provide full image path so the pathname should start with `/posts/`.
-- `hero` - Object with properties: `imageSrc` and `imageAlt`. The `imageSrc` property is a path to hero image which is displayed post page. The `imageAlt` property is alternative text for the image. The image should be added to the `src/apps/labs/public/posts/<post-name>` directory, example: `src/apps/labs/public/posts/hello-world-post`. There is no need to provide full image path so the pathname should start with `/posts/`.
+- `featuredImage` - Object with properties: `src` and `alt`. The `src` property is a path to featured image which is displayed on the posts list on the`/blog` page. The `alt` property is alternative text for the image. The image should be added to the `apps/labs/public/posts/<post-name>` directory, example: `apps/labs/public/posts/hello-world-post`. There is no need to provide full image path so the pathname should start with `/posts/`.
+- `hero` - Object with properties: `imageSrc` and `imageAlt`. The `imageSrc` property is a path to hero image which is displayed post page. The `imageAlt` property is alternative text for the image. The image should be added to the `apps/labs/public/posts/<post-name>` directory, example: `apps/labs/public/posts/hello-world-post`. There is no need to provide full image path so the pathname should start with `/posts/`.
 
 #### Example of blog post meta section
 
@@ -64,9 +64,9 @@ Every post is structured with two main sections - the `meta` and `content` secti
 ### Adding new blog post
 
 1.  Create new feature branch. Example `feature/new-hello-world-post`.
-2.  Add `.md|.mdx` file inside `src/apps/labs/posts` directory.
-3.  Add post feature image inside `src/apps/labs/public/posts/<post-name>`.
-4.  Add post hero image inside `src/apps/labs/public/posts/<post-name>`.
+2.  Add `.md|.mdx` file inside `apps/labs/posts` directory.
+3.  Add post feature image inside `apps/labs/public/posts/<post-name>`.
+4.  Add post hero image inside `apps/labs/public/posts/<post-name>`.
 5.  Add all of the meta information between `---` inside `.md|.mdx` file.
 6.  After `---` add post content
 7.  Save file.
@@ -77,7 +77,7 @@ Every post is structured with two main sections - the `meta` and `content` secti
 ### Adding new blog category
 
 1.  Create new feature branch.
-2.  Open `src/apps/labs/posts/categories.json` file.
+2.  Open `apps/labs/posts/categories.json` file.
 3.  Add new category to array.
 4.  Save file
 5.  Commit and push changes to the repository. For commits please follow the conventional commits format. [See](https://www.conventionalcommits.org/en/v1.0.0/)
@@ -86,6 +86,6 @@ Every post is structured with two main sections - the `meta` and `content` secti
 
 ### Adding new components for usage inside `mdx` posts.
 
-1.  Open `src/apps/labs/services/blogAllowedComponents.ts` file
+1.  Open `apps/labs/services/blogAllowedComponents.ts` file
 2.  Import component from the codebase
 3.  Add to new component to `blogAllowedComponents` object.

--- a/apps/labs/posts/categories.json
+++ b/apps/labs/posts/categories.json
@@ -1,11 +1,13 @@
 [
-  "Machine Learning",
-  "Data Visualization",
-  "Array API",
-  "PyData ecosystem",
   "Accessibility",
-  "Funding",
-  "Comunity",
+  "Array API",
+  "Beyond PyData",
+  "Community",
   "Developer workflows",
-  "IDEs"
+  "Funding",
+  "IDEs",
+  "Machine Learning",
+  "OSS Experience",
+  "Packaging",
+  "PyData ecosystem"
 ]


### PR DESCRIPTION
- The README had references to /src which was outdated
- The blog categories needed to be updated before for migration of the old Labs blog posts