### PR TITLE
Allow Column text to be optional

### DIFF
--- a/apps/consulting/components/Columns/Column/Column.tsx
+++ b/apps/consulting/components/Columns/Column/Column.tsx
@@ -27,13 +27,15 @@ export const Column: FC<TColumnComponentProps> = ({
     <ColumnImage variant={variant} imageSrc={imageSrc} imageAlt={imageAlt} />
     <h3
       className="
-        my-[1.8rem] text-[2.7rem] font-extrabold leading-[3.5rem] text-black lg:mt-[2.6rem] 
+        my-[1.8rem] text-[2.7rem] font-extrabold leading-[3.5rem] text-black lg:mt-[2.6rem]
         font-heading
       "
     >
       {title}
     </h3>
-    <p className="text-[1.6rem] leading-[2.7rem] text-black">{text}</p>
+    {text && (
+      <p className="text-[1.6rem] leading-[2.7rem] text-black">{text}</p>
+    )}
     <ColumnLink linkText={linkText} linkUrl={linkUrl} />
   </div>
 );

--- a/apps/consulting/components/Columns/Column/types.ts
+++ b/apps/consulting/components/Columns/Column/types.ts
@@ -17,7 +17,7 @@ export type TColumnImageProps = {
 export type TColumnProps = {
   _uid?: string;
   title: string;
-  text: string;
+  text?: string;
 } & TColumnImageProps &
   TColumnLinkProps;
 


### PR DESCRIPTION
Fixes #196.

In conjunction with this PR, I also changed the schema in Storyblok so that column.text is NOT required, as shown in the following screenshot:

<img width="243" alt="required checkbox unchecked" src="https://user-images.githubusercontent.com/317883/174441957-e36802a7-5b32-423f-8d3f-8607fbf59b38.png">
