### PR TITLE
fix: Hero image should cover the space not shrink to fit

### DIFF
--- a/libs/shared/ui-components/src/Hero/Hero.tsx
+++ b/libs/shared/ui-components/src/Hero/Hero.tsx
@@ -12,7 +12,7 @@ export const Hero: FC<THeroProps> = ({
   imageSrc,
   imageAlt,
   backgroundColor,
-  objectFit = 'contain',
+  objectFit,
 }) => {
   const isLargeHero =
     variant === HeroVariant.Large || variant === HeroVariant.LargeOverlapping;
@@ -39,7 +39,7 @@ export const Hero: FC<THeroProps> = ({
           src={imageSrc}
           alt={imageAlt}
           layout="fill"
-          objectFit={objectFit}
+          objectFit={objectFit || 'cover'}
           objectPosition="center"
         />
         {title && (


### PR DESCRIPTION
This could potentially be a fix for #213, at least a partial fix or a stopgap fix.

Previously, the code was supposedly defaulting to `object-fit: contain` but `cover` matches the [Figma designs](https://www.figma.com/file/vyWM9qXdXCSAPlTfUjuqrL/Quansight-2021-Website?node-id=1181%3A340) much better.

Here are two screenshots showing the difference. Both are at mobile device width.

When object-fit is set to `contain`, the hero image is shrunk down so that it fits, which is not desired:

<img width="543" alt="" src="https://user-images.githubusercontent.com/317883/174498389-e89654f4-7366-470f-a8a3-2b26d1d01434.png">

When object-fit is set to `cover`, the hero image expands across the available space, as desired:

<img width="545" alt="" src="https://user-images.githubusercontent.com/317883/174498404-77dee236-0b7d-47df-a6be-23896b4f53e4.png">

I also had to change the code to not use a default function parameter value for `objectFit` because while debugging, I discovered that the CMS was passing an empty string for `objectFit` when a value for object fit is not chosen in the Storyblok UI.

Here's a snippet of the json returned from `http://localhost:4200/_next/data/development/library.json` in which `objectFit` is assigned an empty string:

```json
{
    "pageProps": {
        "data": {
            "__typename": "PageItem",
            "alternates": [],
            "content": {
                "__typename": "PageComponent",
                "_editable": "<!--#storyblok#{\"name\": \"page\", \"space\": \"147759\", \"uid\": \"52531dbb-5aff-4f6f-a084-fcc2da90c1c1\", \"id\": \"143249754\"}-->",
                "_uid": "52531dbb-5aff-4f6f-a084-fcc2da90c1c1",
                "body": [
                    {
                        "_uid": "5432d60a-c2c8-41a9-9131-13d29e123d97",
                        "image": {
                            "id": 4981932,
                            "alt": "Hero decoration",
                            "name": "",
                            "focus": null,
                            "title": "",
                            "filename": "https://a.storyblok.com/f/147759/1440x746/5cfdc24cd0/paris_v6.png",
                            "copyright": "",
                            "fieldtype": "asset"
                        },
                        "title": "Blog",
                        "variant": "medium",
                        "subTitle": "",
                        "component": "hero",
                        "objectFit": "",
                        "_editable": "<!--#storyblok#{\"name\": \"hero\", \"space\": \"147759\", \"uid\": \"5432d60a-c2c8-41a9-9131-13d29e123d97\", \"id\": \"143249754\"}-->"
                    },
```

And here's a screenshot showing the corresponding empty `Object Fit` field in Storyblok:

<img width="808" alt="" src="https://user-images.githubusercontent.com/317883/174498698-c8289e90-7635-4b2c-83d7-b0f92b434163.png">


