### PR TITLE
Hide library type filter

### DIFF
--- a/apps/consulting/components/Filters/Filters.tsx
+++ b/apps/consulting/components/Filters/Filters.tsx
@@ -43,12 +43,15 @@ export const Filters: FC<TFiltersProps> = ({
 
   return (
     <div className="flex flex-col gap-[2rem] justify-between items-center pb-[5.2rem] w-full sm:flex-row sm:gap-[5rem]">
+      {/*
+      We're removing the type filter until we have content of other types. Right now, we just have blog-type content.
       <FilterMenu
         filterMenuVariant={FilterMenuVariant.Type}
         menuDataCurrent={postFilters.type}
         menuData={postTypes}
         onFilterChange={onFilterChange}
       />
+      */}
       <FilterMenu
         filterMenuVariant={FilterMenuVariant.Category}
         menuDataCurrent={postFilters.category}


### PR DESCRIPTION
The following screenshot shows that this code change removes the type filter bar from the library page. The categories dropdown, which used to appear on the right, takes its place:

<img width="1162" alt="" src="https://user-images.githubusercontent.com/317883/176193971-f402fbb4-a15b-4891-a8e1-fb47b54adb2e.png">

I noticed when working on this, that the default type (when no type has been selected) for the library is "All", which is perfect for what we want.