### PR TITLE
fix: make util function return only blog posts to avoid errors

### DIFF
--- a/apps/labs/pages/blog/[slug].tsx
+++ b/apps/labs/pages/blog/[slug].tsx
@@ -27,6 +27,7 @@ import { POSTS_DIRECTORY_PATH } from '../../services/api/posts/constants';
 import { getPost } from '../../services/api/posts/getPost';
 import { getPostsByCategory } from '../../services/api/posts/getPostsByCategory';
 import { blogAllowedComponents } from '../../services/blogAllowedComponents';
+import { getAllPostFileNames } from '../../services/posts/getAllPostFileNames';
 import { TPost } from '../../types/storyblok/bloks/posts';
 
 export type TBlogPostProps = {
@@ -93,12 +94,12 @@ export const BlogPost: FC<TBlogPostProps> = ({
 
 export const getStaticPaths: GetStaticPaths = async () => {
   try {
-    const postsFileNames = await readdir(path.join(POSTS_DIRECTORY_PATH));
+    const postsFileNames = getAllPostFileNames();
 
     return {
-      paths: postsFileNames
-        .filter((filename) => /\.(md|mdx)$/.test(filename))
-        .map((filename) => `/blog/${filename.replace(/\.(md|mdx)$/, '')}`),
+      paths: postsFileNames.map(
+        (filename) => `/blog/${filename.replace(/\.(md|mdx)$/, '')}`,
+      ),
       fallback: false,
     };
   } catch (error) {

--- a/apps/labs/services/api/posts/getAllPosts.ts
+++ b/apps/labs/services/api/posts/getAllPosts.ts
@@ -1,6 +1,9 @@
 import { getTeam } from '../../../api/utils/getTeam';
 import { TPostsResponse } from '../../../types/storyblok/bloks/posts';
-import { getPostsDirectory } from '../../posts/getPostsDirectory';
+import {
+  getAllPostFileNames,
+  postFileExtensionRegExp,
+} from '../../posts/getAllPostFileNames';
 import { serializePost } from '../../posts/serializePost';
 import { sortPostsByDate } from '../../posts/sortPostsByDate';
 import { DEFAULT_API_OFFSET } from './constants';
@@ -8,14 +11,11 @@ import { DEFAULT_API_OFFSET } from './constants';
 export const getAllPosts = async (): Promise<TPostsResponse> => {
   try {
     const team = await getTeam();
-    const postsFileNames = getPostsDirectory();
-    const postsFileNamesFiltered = postsFileNames.filter(
-      (fileName) => fileName !== 'categories.json',
-    );
+    const postsFileNames = getAllPostFileNames();
 
     const posts = await Promise.all(
-      postsFileNamesFiltered.map(async (fileName) => {
-        const slug = fileName.replace(/\.(md|mdx)$/, '');
+      postsFileNames.map(async (fileName) => {
+        const slug = fileName.replace(postFileExtensionRegExp, '');
         const { content, meta } = await serializePost(fileName, team);
 
         return {

--- a/apps/labs/services/api/posts/getPost.ts
+++ b/apps/labs/services/api/posts/getPost.ts
@@ -1,12 +1,12 @@
 import { getTeam } from '../../../api';
 import { TPost } from '../../../types/storyblok/bloks/posts';
-import { getPostsDirectory } from '../../posts/getPostsDirectory';
+import { getAllPostFileNames } from '../../posts/getAllPostFileNames';
 import { serializePost } from '../../posts/serializePost';
 
 export const getPost = async (slug: string): Promise<TPost | undefined> => {
   try {
     const team = await getTeam();
-    const postsFileNames = getPostsDirectory();
+    const postsFileNames = getAllPostFileNames();
     const fileName = postsFileNames.find((name) => name.startsWith(slug));
 
     if (!fileName) {

--- a/apps/labs/services/posts/getAllPostFileNames.ts
+++ b/apps/labs/services/posts/getAllPostFileNames.ts
@@ -1,0 +1,11 @@
+import { readdirSync } from 'fs';
+import path from 'path';
+
+import { POSTS_DIRECTORY_PATH } from '../api/posts/constants';
+
+export const postFileExtensionRegExp = /\.(md|mdx)$/;
+
+export const getAllPostFileNames = (): string[] =>
+  readdirSync(path.join(process.cwd(), POSTS_DIRECTORY_PATH)).filter(
+    (fileName) => postFileExtensionRegExp.test(fileName),
+  );

--- a/apps/labs/services/posts/getPostsDirectory.ts
+++ b/apps/labs/services/posts/getPostsDirectory.ts
@@ -1,7 +1,0 @@
-import { readdirSync } from 'fs';
-import path from 'path';
-
-import { POSTS_DIRECTORY_PATH } from '../api/posts/constants';
-
-export const getPostsDirectory = (): string[] =>
-  readdirSync(path.join(process.cwd(), POSTS_DIRECTORY_PATH));


### PR DESCRIPTION
I was getting an error when trying to serve the Labs blog locally because files that were added by my system (.DS_Store) were getting picked up by the util function `getPostsDirectory`.

I looked at the how the function is used in the codebase and realized it would improve the code to have the function only return .md and .mdx files from the posts directory. I also renamed the function to getAllPostFileNames, so that the name is more explicit about what the function does.