### PR TITLE
fix: Adjust line spacing in Consulting drop down in header

### DIFF
--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdown.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdown.tsx
@@ -75,7 +75,7 @@ export const HeaderDesktopDropdown: FC<THeaderDesktopDropdownProps> = ({
         <div className="absolute top-full right-0 z-20 pt-[2.4rem] w-max max-w-[25rem]">
           <ul
             id="options"
-            className="flex flex-col gap-[0.8rem] justify-between items-start p-[2.8rem] min-w-[19.8rem] text-left text-black bg-white/90"
+            className="flex flex-col gap-[1.8rem] justify-between items-start p-[2.8rem] min-w-[19.8rem] text-left text-black bg-white/90"
           >
             {links.map((link) => (
               <HeaderDesktopDropdownLink

--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdownLink.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdownLink.tsx
@@ -19,7 +19,7 @@ export const HeaderDesktopDropdownLink: FC<THeaderDesktopDropdownLinkProps> = ({
 
   return (
     <button
-      className="text-[1.7rem] font-normal leading-[2.825rem] text-left capitalize transition-colors motion-reduce:transition-none ease-in-out hover:text-green font-heading focus:text-green"
+      className="text-[1.7rem] font-normal leading-[2.225rem] text-left capitalize transition-colors motion-reduce:transition-none ease-in-out hover:text-green font-heading focus:text-green"
       onClick={onButtonClick}
     >
       {linkText}


### PR DESCRIPTION
Increase `gap` class property for line spacing between list elements.

Decrease `leading` class property for line spacing within each list element.

A further change after #194.
