### PR TITLE
fix: Change Labs post hero variant from small to medium

### DIFF
--- a/apps/labs/pages/blog/[slug].tsx
+++ b/apps/labs/pages/blog/[slug].tsx
@@ -59,7 +59,7 @@ export const BlogPost: FC<TBlogPostProps> = ({
       {post.meta.hero && (
         <Hero
           {...post.meta.hero}
-          variant={HeroVariant.Small}
+          variant={HeroVariant.Medium}
           backgroundColor="transparent"
           objectFit="cover"
         />


### PR DESCRIPTION
Currently, when the browser screen is wide, a lot of the top of the blog hero image is hidden:

![](https://user-images.githubusercontent.com/317883/176932014-2d51d26a-6eac-41ee-aa15-5f4a56c38d88.png)

But we want it to look more like this, with none of the hero image hidden:

![](https://user-images.githubusercontent.com/317883/176931946-e1e87e11-d54b-4f55-866c-c3beb018abb7.png)
