### PR TITLE
fix: Change link spacing in FooterNavigation.tsx

### DIFF
--- a/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterNavigation.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterNavigation.tsx
@@ -15,8 +15,8 @@ export const FooterNavigation: FC<TFooterNavigationProps> = ({
     <nav className="flex flex-col">
       {links.map(({ linkText, linkUrl, _uid }) => (
         <Link href={`/${linkUrl.cached_url}`} key={_uid}>
-          <a className="text-[1.4rem] font-normal leading-[2.3rem]">
-            {linkText}<br />
+          <a className="text-[1.4rem] font-normal leading-[2.3rem] pb-5">
+            {linkText}
           </a>
         </Link>
       ))}

--- a/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterNavigation.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterNavigation.tsx
@@ -16,8 +16,8 @@ export const FooterNavigation: FC<TFooterNavigationProps> = ({
       {links.map(({ linkText, linkUrl, _uid }) => (
         <Link href={`/${linkUrl.cached_url}`} key={_uid}>
           <a className="text-[1.4rem] font-normal leading-[2.3rem]">
-            {linkText}
-          </a><br />
+            {linkText}<br />
+          </a>
         </Link>
       ))}
     </nav>

--- a/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterNavigation.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterNavigation.tsx
@@ -15,9 +15,9 @@ export const FooterNavigation: FC<TFooterNavigationProps> = ({
     <nav className="flex flex-col">
       {links.map(({ linkText, linkUrl, _uid }) => (
         <Link href={`/${linkUrl.cached_url}`} key={_uid}>
-          <a className="text-[1.4rem] font-normal leading-[3.3rem]">
+          <a className="text-[1.4rem] font-normal leading-[2.3rem]">
             {linkText}
-          </a>
+          </a><br />
         </Link>
       ))}
     </nav>


### PR DESCRIPTION
Decrease the line spacing via change to `leading-[2.3rem]`.

Add an HTML linebreak to separate the individual links from each other.

Fixes #184.
