### PR TITLE
fix: First batch of accessibility fixes for Consulting homepage

### DIFF
--- a/apps/consulting/components/Board/BoardItem.tsx
+++ b/apps/consulting/components/Board/BoardItem.tsx
@@ -30,23 +30,23 @@ const BoardItem: FC<TBoardItemProps & { classNameBorder: string }> = ({
           priority
         />
       </div>
-      <h3 className="text-[2.2rem] font-extrabold leading-[3rem] sm:mt-[2.8rem] sm:mb-[2.2rem] xl:mt-[3.6rem] xl:mb-[2.2rem] font-heading">
-        {title}
-      </h3>
-      <div className="flex">
-        <Link href={linkUrl}>
-          <a className="flex gap-3 justify-center items-center mx-auto w-auto text-[1.6rem] font-bold leading-[3.7rem]">
+      <Link href={linkUrl}>
+        <a>
+          <div className="text-[2.2rem] font-extrabold leading-[3rem] sm:mt-[2.8rem] sm:mb-[2.2rem] xl:mt-[3.6rem] xl:mb-[2.2rem] font-heading">
+            {title}
+          </div>
+          <div className="flex gap-3 justify-center items-center mx-auto w-auto text-[1.6rem] font-bold leading-[3.7rem]">
             {linkTitle}
             <Picture
               imageSrc="/board/board-btn-arrow.svg"
-              imageAlt="arrow icon"
+              imageAlt=""
               width={12}
               height={17}
               priority
             />
-          </a>
-        </Link>
-      </div>
+          </div>
+        </a>
+      </Link>
     </div>
   );
 };

--- a/apps/consulting/components/Board/BoardItem.tsx
+++ b/apps/consulting/components/Board/BoardItem.tsx
@@ -12,7 +12,6 @@ const BoardItem: FC<TBoardItemProps & { classNameBorder: string }> = ({
   linkTitle,
   linkUrl,
   imageSrc,
-  imageAlt,
   classNameBorder,
 }) => {
   return (
@@ -22,16 +21,17 @@ const BoardItem: FC<TBoardItemProps & { classNameBorder: string }> = ({
         classNameBorder,
       )}
     >
-      <div className="relative h-32">
-        <Picture
-          imageSrc={imageSrc}
-          imageAlt={imageAlt}
-          layout="fill"
-          priority
-        />
-      </div>
       <Link href={linkUrl}>
         <a>
+          <div className="relative h-32">
+            <Picture
+              imageSrc={imageSrc}
+              // Alt text deliberately empty because the images used here are decorative.
+              imageAlt=""
+              layout="fill"
+              priority
+            />
+          </div>
           <div className="text-[2.2rem] font-extrabold leading-[3rem] sm:mt-[2.8rem] sm:mb-[2.2rem] xl:mt-[3.6rem] xl:mb-[2.2rem] font-heading">
             {title}
           </div>

--- a/apps/consulting/components/Board/decorations/ButtonDecoration.tsx
+++ b/apps/consulting/components/Board/decorations/ButtonDecoration.tsx
@@ -6,7 +6,7 @@ export const ButtonDecoration: FC = () => (
   <div className="hidden absolute top-[85%] right-[5%] w-[37.1rem] h-[22.5rem] lg:block xl:top-[77%] xl:right-[2%]">
     <Picture
       imageSrc="/board/board-btn-icon.svg"
-      imageAlt="button geomatric decoration"
+      imageAlt=""
       layout="responsive"
       width={371}
       height={225}

--- a/apps/consulting/components/Board/decorations/HeaderDecoration.tsx
+++ b/apps/consulting/components/Board/decorations/HeaderDecoration.tsx
@@ -6,7 +6,7 @@ export const HeaderDecoration: FC = () => (
   <div className="hidden absolute top-[6%] left-[6%] w-[16.6rem] h-[12.5rem] lg:block xl:top-[15%] xl:left-[2%]">
     <Picture
       imageSrc="/board/board-header-icon.svg"
-      imageAlt="header geometric decoration"
+      imageAlt=""
       layout="responsive"
       width={166}
       height={125}

--- a/apps/consulting/tailwind.config.js
+++ b/apps/consulting/tailwind.config.js
@@ -18,7 +18,6 @@ module.exports = {
         violet: '#452393',
         pink: '#A43A8F',
         green: '#99C941',
-        darkgreen: '#558300',
         black: '#191919',
         white: '#ffffff',
         lightgray: '#fafaff',

--- a/apps/consulting/tailwind.config.js
+++ b/apps/consulting/tailwind.config.js
@@ -18,6 +18,7 @@ module.exports = {
         violet: '#452393',
         pink: '#A43A8F',
         green: '#99C941',
+        darkgreen: '#558300',
         black: '#191919',
         white: '#ffffff',
         lightgray: '#fafaff',

--- a/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterNavigation.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterNavigation.tsx
@@ -12,14 +12,18 @@ export const FooterNavigation: FC<TFooterNavigationProps> = ({
     <h2 className="pb-[1.3rem] mb-4 text-[1.6rem] font-bold leading-[3rem] border-b-[0.5px] border-black xl:border-white">
       {title}
     </h2>
-    <nav className="flex flex-col">
-      {links.map(({ linkText, linkUrl, _uid }) => (
-        <Link href={`/${linkUrl.cached_url}`} key={_uid}>
-          <a className="text-[1.4rem] font-normal leading-[3.3rem]">
-            {linkText}
-          </a>
-        </Link>
-      ))}
-    </nav>
+    <div className="flex flex-col">
+      <ul>
+        {links.map(({ linkText, linkUrl, _uid }) => (
+          <li key={_uid}>
+            <Link href={`/${linkUrl.cached_url}`} key={_uid}>
+              <a className="text-[1.4rem] font-normal leading-[3.3rem]">
+                {linkText}
+              </a>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
   </div>
 );

--- a/libs/shared/ui-components/src/Footer/FooterCopyright.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterCopyright.tsx
@@ -9,13 +9,13 @@ export const FooterCopyright: FC<TFooterCopyrightProps> = ({
   copyright,
 }) => (
   <section className="items-center pt-8 mt-[3.7rem] border-t-[0.5px] border-black sm:flex sm:gap-[2.7rem] sm:mt-[8.5rem] xl:border-white">
-    <nav className="flex gap-[2.4rem] justify-start items-center sm:gap-[2.7rem]">
+    <div className="flex gap-[2.4rem] justify-start items-center sm:gap-[2.7rem]">
       {policyAndConditions.map(({ linkText, linkUrl, _uid }) => (
         <Link href={`/${linkUrl.cached_url}`} key={_uid}>
           <a className="text-[1.2rem] leading-[2.4rem]">{linkText}</a>
         </Link>
       ))}
-    </nav>
+    </div>
     <p className="mt-2 text-[1.2rem] leading-[2.4rem] sm:mt-0">{copyright}</p>
   </section>
 );

--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdown.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdown.tsx
@@ -75,7 +75,7 @@ export const HeaderDesktopDropdown: FC<THeaderDesktopDropdownProps> = ({
         <div className="absolute top-full right-0 z-20 pt-[2.4rem] w-max max-w-[25rem]">
           <ul
             id="options"
-            className="flex flex-col gap-[1.8rem] justify-between items-start p-[2.8rem] min-w-[19.8rem] text-left text-black bg-white/90"
+            className="flex flex-col gap-[1.8rem] justify-between items-start p-[2.8rem] min-w-[19.8rem] text-left text-black bg-white"
           >
             {links.map((link) => (
               <HeaderDesktopDropdownLink

--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdownLink.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdownLink.tsx
@@ -19,7 +19,7 @@ export const HeaderDesktopDropdownLink: FC<THeaderDesktopDropdownLinkProps> = ({
 
   return (
     <button
-      className="text-[1.7rem] font-normal leading-[2.225rem] text-left capitalize transition-colors motion-reduce:transition-none ease-in-out hover:text-green font-heading focus:text-green"
+      className="text-[1.7rem] font-normal leading-[2.225rem] text-left capitalize transition-colors motion-reduce:transition-none ease-in-out hover:text-darkgreen focus:text-darkgreen font-heading"
       onClick={onButtonClick}
     >
       {linkText}

--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdownLink.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdownLink.tsx
@@ -19,7 +19,7 @@ export const HeaderDesktopDropdownLink: FC<THeaderDesktopDropdownLinkProps> = ({
 
   return (
     <button
-      className="text-[1.7rem] font-normal leading-[2.225rem] text-left capitalize transition-colors motion-reduce:transition-none ease-in-out hover:text-darkgreen focus:text-darkgreen font-heading"
+      className="text-[1.7rem] font-normal leading-[2.225rem] text-left focus:underline capitalize transition-colors motion-reduce:transition-none ease-in-out font-heading"
       onClick={onButtonClick}
     >
       {linkText}

--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdownLink.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdownLink.tsx
@@ -19,7 +19,7 @@ export const HeaderDesktopDropdownLink: FC<THeaderDesktopDropdownLinkProps> = ({
 
   return (
     <button
-      className="text-[1.7rem] font-normal leading-[2.225rem] text-left focus:underline capitalize transition-colors motion-reduce:transition-none ease-in-out font-heading"
+      className="text-[1.7rem] font-normal leading-[2.225rem] text-left hover:underline focus:underline capitalize transition-colors motion-reduce:transition-none ease-in-out font-heading"
       onClick={onButtonClick}
     >
       {linkText}


### PR DESCRIPTION
This is my first batch of tweaks to improve the accessibility of the Consulting homepage. Note that many of these fixes will carry over to other Consulting pages, as well as Labs pages, but they were all derived from manually inspecting the Consulting homepage.

There are a few issues on the homepage that I'm not tackling in this PR:

- There are three links that currently just say "Learn more." Fixing these either requires a copy change or a non-trivial change in Storyblok and/or the codebase.
- Not sure the following should be an h3: "Turning data into insights with open source software."
- The skip link does not scroll past the top nav bar. 
- I think clicking "Consulting" in the nav bar should make the menu stay open until clicking elsewhere (don't close menu on mouse out).