### PR TITLE
fix: Fix book a call link in mobile nav menu

### DIFF
--- a/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileBookingLink.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileBookingLink.tsx
@@ -18,7 +18,7 @@ export const HeaderMobileBookingLink: FC<TBookingLinkProps> = ({
     setIsNavigationOpen(false);
     const url =
       domainVariant === DomainVariant.Quansight
-        ? `/about#${BOOK_A_CALL_FORM_ID}`
+        ? `/about-us#${BOOK_A_CALL_FORM_ID}`
         : `/#${BOOK_A_CALL_FORM_ID}`;
 
     router.push(url);


### PR DESCRIPTION
Needed to be switched from `/about` to `/about-us`.

No associated issue.