### PR TITLE
fix: type error in build related to hero variants

### DIFF
--- a/libs/shared/ui-components/src/Hero/types.ts
+++ b/libs/shared/ui-components/src/Hero/types.ts
@@ -33,9 +33,9 @@ export type THeroProps = {
   imageAlt: string;
   backgroundColor?: string;
   objectFit?: ImageProps['objectFit'];
-  imageMobile: TCustomImage;
-  imageTablet: TCustomImage;
-  imageDesktop: TCustomImage;
+  imageMobile?: TCustomImage;
+  imageTablet?: TCustomImage;
+  imageDesktop?: TCustomImage;
 };
 
 export default THeroProps;


### PR DESCRIPTION
PR #247 was failing to build on Vercel. After I pushed a commit to that PR to make the [variant props optional](https://github.com/Quansight/Quansight-website/pull/247/commits/ee6a5dc55ebf25766c68e6a800d16195f93dddc0), Vercel was able to build the website: https://quansight-labs-live-g48hbzs03-quansight.vercel.app/