### PR TITLE
fix: differentiate Learn More links on Consulting home

### DIFF
--- a/apps/consulting/components/StickyNotes/StickyNote/Button.tsx
+++ b/apps/consulting/components/StickyNotes/StickyNote/Button.tsx
@@ -5,14 +5,16 @@ import { ButtonLink, ButtonColor } from '@quansight/shared/ui-components';
 type TButtonProps = {
   link: string;
   text: string;
+  linkAriaLabel?: string;
 };
 
-export const Button: FC<TButtonProps> = ({ link, text }) => (
+export const Button: FC<TButtonProps> = ({ link, text, linkAriaLabel }) => (
   <div className="mt-[1.4rem] sm:mt-[3.8rem]">
     <ButtonLink
       isFull
       isTriangle
       url={link}
+      ariaLabel={linkAriaLabel}
       text={text}
       color={ButtonColor.White}
     />

--- a/apps/consulting/components/StickyNotes/StickyNote/StickyNote.tsx
+++ b/apps/consulting/components/StickyNotes/StickyNote/StickyNote.tsx
@@ -45,7 +45,7 @@ export const StickyNote: FC<TStickyNoteComponentProps> = ({
       {showButton && (
         <Button
           text={buttonText}
-          linkAriaLabel={`${title} {buttonText}`}
+          linkAriaLabel={`${title} ${buttonText}`}
           link={buttonLink}
         />
       )}

--- a/apps/consulting/components/StickyNotes/StickyNote/StickyNote.tsx
+++ b/apps/consulting/components/StickyNotes/StickyNote/StickyNote.tsx
@@ -42,7 +42,13 @@ export const StickyNote: FC<TStickyNoteComponentProps> = ({
         size={descriptionSize}
         variant={variant}
       />
-      {showButton && <Button text={buttonText} link={buttonLink} />}
+      {showButton && (
+        <Button
+          text={buttonText}
+          linkAriaLabel={`${title} {buttonText}`}
+          link={buttonLink}
+        />
+      )}
     </div>
   );
 };

--- a/libs/shared/ui-components/src/ButtonLink/ButtonLink.tsx
+++ b/libs/shared/ui-components/src/ButtonLink/ButtonLink.tsx
@@ -12,6 +12,7 @@ export const ButtonLink: FC<TButtonLinkProps> = ({
   color = ButtonColor.Violet,
   text,
   url,
+  ariaLabel,
 }) => (
   <Link href={url}>
     <a
@@ -26,6 +27,9 @@ export const ButtonLink: FC<TButtonLinkProps> = ({
             color === ButtonColor.Violet ? 'border-violet' : 'border-white'
           }`,
       )}
+      // When ariaLabel is null or undefined, then attribute aria-label is not
+      // put on the element in the rendered HTML.
+      aria-label={ariaLabel}
     >
       {text}
       {isTriangle && (

--- a/libs/shared/ui-components/src/ButtonLink/types.ts
+++ b/libs/shared/ui-components/src/ButtonLink/types.ts
@@ -11,4 +11,5 @@ export type TButtonLinkProps = {
   color: ButtonColor;
   text: string;
   url: string;
+  ariaLabel: string;
 };


### PR DESCRIPTION
This PR is intended to only affect the Consulting home page (I think that's the only place where the StickyNote component is used with a Learn More link). 

Instead of having two links that appear in the links list as:

Learn More 
Learn More

They will appear as:

Consulting Learn More
Labs Learn More

Important: this does not affect the __visual__ representation of links, only the way they are represented to assistive tech (screen readers).