### PR TITLE
fix: remove link to book a call from Labs mobile menu

### DIFF
--- a/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileNavigation.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileNavigation.tsx
@@ -2,6 +2,8 @@ import { FC } from 'react';
 
 import clsx from 'clsx';
 
+import { DomainVariant } from '@quansight/shared/types';
+
 import { HeaderMobileBookingLink } from './HeaderMobileBookingLink';
 import { HeaderMobileNavigationProvider } from './HeaderMobileNavigationProvider/HeaderMobileNavigationProvider';
 import { THeaderMobileNavigationProps } from './types';
@@ -37,11 +39,13 @@ export const HeaderMobileNavigation: FC<THeaderMobileNavigationProps> = ({
           </li>
         ))}
       </ul>
-      <HeaderMobileBookingLink
-        bookACallLinkText={bookACallLinkText}
-        domainVariant={domainVariant}
-        setIsNavigationOpen={setIsNavigationOpen}
-      />
+      {domainVariant === DomainVariant.Quansight && (
+        <HeaderMobileBookingLink
+          bookACallLinkText={bookACallLinkText}
+          domainVariant={domainVariant}
+          setIsNavigationOpen={setIsNavigationOpen}
+        />
+      )}
     </div>
   </nav>
 );

--- a/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileNavigation.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileNavigation.tsx
@@ -2,8 +2,6 @@ import { FC } from 'react';
 
 import clsx from 'clsx';
 
-import { DomainVariant } from '@quansight/shared/types';
-
 import { HeaderMobileBookingLink } from './HeaderMobileBookingLink';
 import { HeaderMobileNavigationProvider } from './HeaderMobileNavigationProvider/HeaderMobileNavigationProvider';
 import { THeaderMobileNavigationProps } from './types';
@@ -39,7 +37,7 @@ export const HeaderMobileNavigation: FC<THeaderMobileNavigationProps> = ({
           </li>
         ))}
       </ul>
-      {domainVariant === DomainVariant.Quansight && (
+      {bookACallLinkText && (
         <HeaderMobileBookingLink
           bookACallLinkText={bookACallLinkText}
           domainVariant={domainVariant}


### PR DESCRIPTION
### How to test this PR

Consulting 

- Go to -live preview URL on mobile browser (or emulate mobile in desktop browser).
- Open hamburger menu.
- Verify that the "book a call" link is in the menu and that clicking it takes you to the contact form.

Labs:

- Go to -live preview URL on mobile browser.
- Open hamburger menu.
- Verify that the "book a call" link is no longer in the menu.