### PR TITLE
fix: Switch getPageItems Apollo query fetch policy to network only

### DIFF
--- a/apps/consulting/utils/getLibraryTiles/getBlogArticlesProps.ts
+++ b/apps/consulting/utils/getLibraryTiles/getBlogArticlesProps.ts
@@ -12,6 +12,10 @@ export const getBlogArticlesProps = (blogArticles: PageItems): TTiles =>
       ),
     };
 
+    if ( typeof blogArticleBodyItem.author.content === 'undefined' ) {
+      console.log(blogArticleBodyItem);
+    }
+
     /* blogArticleBodyItem.author could be a Promise */
     let author = '';
     let author_obj = blogArticleBodyItem.author;

--- a/apps/consulting/utils/getLibraryTiles/getBlogArticlesProps.ts
+++ b/apps/consulting/utils/getLibraryTiles/getBlogArticlesProps.ts
@@ -13,16 +13,19 @@ export const getBlogArticlesProps = (blogArticles: PageItems): TTiles =>
     };
 
     if ( typeof blogArticleBodyItem.author.content === 'undefined' ) {
-      console.log(blogArticleBodyItem);
+      console.log(`Title: ${blogArticleBodyItem.postTitle}`);
+      console.log(`Incoming Author: ${blogArticleBodyItem.author}`);
     }
 
-    /* blogArticleBodyItem.author could be a Promise */
+    // blogArticleBodyItem.author could be a Promise
     let author = '';
     let author_obj = blogArticleBodyItem.author;
     if (typeof author_obj === 'object' && typeof author_obj.then === 'function') {
       let promise_author = {author: ''};
-      author_obj.then( auth => promise_author.author = getAuthorName(auth.content.firstName, auth.content.lastName) );
-      author = promise_author.author
+      // author_obj.then( auth => promise_author.author = getAuthorName(auth.content.firstName, auth.content.lastName) );
+      // author = promise_author.author
+      author_obj.then( auth => console.log(`Resolved Author: ${auth}`) );
+      author = "Placeholder Author Name";
     } else {
       author = getAuthorName(author_obj.content.firstName, author_obj.content.lastName);
     };

--- a/apps/consulting/utils/getLibraryTiles/getBlogArticlesProps.ts
+++ b/apps/consulting/utils/getLibraryTiles/getBlogArticlesProps.ts
@@ -11,27 +11,6 @@ export const getBlogArticlesProps = (blogArticles: PageItems): TTiles =>
         (bodyItem) => bodyItem.component === 'blog-article',
       ),
     };
-
-    if ( typeof blogArticleBodyItem.author.content === 'undefined' ) {
-      console.log(`Title: ${blogArticleBodyItem.postTitle}`);
-      console.log(`Incoming Author: ${blogArticleBodyItem.author}`);
-    }
-
-    // blogArticleBodyItem.author could be a Promise
-    let author = '';
-    let author_obj = blogArticleBodyItem.author;
-    if (typeof author_obj === 'object' && typeof author_obj.then === 'function') {
-      console.log('Author with Promise value found, attempting to process.')
-      let promise_author = {author: ''};
-      // author_obj.then( auth => promise_author.author = getAuthorName(auth.content.firstName, auth.content.lastName) );
-      // author = promise_author.author
-      author_obj.then( auth => console.log(`Resolved Author: ${auth}`) );
-      author = "Placeholder Author Name";
-    } else {
-      console.log('Resolved author found')
-      author = getAuthorName(author_obj.content.firstName, author_obj.content.lastName);
-    };
-
     return {
       uuid: article.uuid,
       link: getLinkType(article),
@@ -40,7 +19,10 @@ export const getBlogArticlesProps = (blogArticles: PageItems): TTiles =>
       postType: blogArticleBodyItem.type,
       postCategory: blogArticleBodyItem.category,
       title: blogArticleBodyItem.postTitle,
-      author: author,
+      author: getAuthorName(
+        blogArticleBodyItem.author.content.firstName,
+        blogArticleBodyItem.author.content.lastName,
+      ),
       date: formatArticleDate(blogArticleBodyItem.publishedDate),
     };
   });

--- a/apps/consulting/utils/getLibraryTiles/getBlogArticlesProps.ts
+++ b/apps/consulting/utils/getLibraryTiles/getBlogArticlesProps.ts
@@ -11,6 +11,18 @@ export const getBlogArticlesProps = (blogArticles: PageItems): TTiles =>
         (bodyItem) => bodyItem.component === 'blog-article',
       ),
     };
+
+    /* blogArticleBodyItem.author could be a Promise */
+    let author = '';
+    let author_obj = blogArticleBodyItem.author;
+    if (typeof author_obj === 'object' && typeof author_obj.then === 'function') {
+      let promise_author = {author: ''};
+      author_obj.then( auth => promise_author.author = getAuthorName(auth.content.firstName, auth.content.lastName) );
+      author = promise_author.author
+    } else {
+      author = getAuthorName(author_obj.content.firstName, author_obj.content.lastName);
+    };
+
     return {
       uuid: article.uuid,
       link: getLinkType(article),
@@ -19,10 +31,7 @@ export const getBlogArticlesProps = (blogArticles: PageItems): TTiles =>
       postType: blogArticleBodyItem.type,
       postCategory: blogArticleBodyItem.category,
       title: blogArticleBodyItem.postTitle,
-      author: getAuthorName(
-        blogArticleBodyItem.author.content.firstName,
-        blogArticleBodyItem.author.content.lastName,
-      ),
+      author: author,
       date: formatArticleDate(blogArticleBodyItem.publishedDate),
     };
   });

--- a/apps/consulting/utils/getLibraryTiles/getBlogArticlesProps.ts
+++ b/apps/consulting/utils/getLibraryTiles/getBlogArticlesProps.ts
@@ -21,12 +21,14 @@ export const getBlogArticlesProps = (blogArticles: PageItems): TTiles =>
     let author = '';
     let author_obj = blogArticleBodyItem.author;
     if (typeof author_obj === 'object' && typeof author_obj.then === 'function') {
+      console.log('Author with Promise value found, attempting to process.')
       let promise_author = {author: ''};
       // author_obj.then( auth => promise_author.author = getAuthorName(auth.content.firstName, auth.content.lastName) );
       // author = promise_author.author
       author_obj.then( auth => console.log(`Resolved Author: ${auth}`) );
       author = "Placeholder Author Name";
     } else {
+      console.log('Resolved author found')
       author = getAuthorName(author_obj.content.firstName, author_obj.content.lastName);
     };
 

--- a/libs/shared/storyblok-sdk/src/api/utils/getPageItems.ts
+++ b/libs/shared/storyblok-sdk/src/api/utils/getPageItems.ts
@@ -7,7 +7,7 @@ export const getPageItems = <ResultType, VariablesType>(
   variables: VariablesType,
 ): Promise<ApolloQueryResult<ResultType>> => {
   return apolloClient.query({
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
     query,
     variables,
   });


### PR DESCRIPTION
If it works, closes #353.

~Adds explicit handling of case where `blogArticleBodyItem.author` is a Promise, instead of an object with the needed author data.~

Change the [Apollo query fetch policy](https://www.apollographql.com/docs/react/data/queries/#supported-fetch-policies) from `cache-first` to `network-only` for `getPageItems`. It seems that the author data in the cache could sometimes be stale -- or perhaps cross-contaminated by concurrent builds? -- leading to garbage data (in the form of a UID) being returned/stored.