### PR TITLE
Create last-content-only-deploy.txt

### DIFF
--- a/last-content-only-deploy.txt
+++ b/last-content-only-deploy.txt
@@ -1,0 +1,11 @@
+This file is used to trigger Vercel deploys when there are no code changes, only content changes in Storyblok.
+
+Here's how it works:
+
+git checkout -b new-branch
+echo `date` >> last-content-only-deploy.txt
+git add last-content-only-deploy.txt
+git commit -m"date last-content-only-deploy.txt"
+git push
+
+Fri Jul 29 15:37:27 CEST 2022

--- a/last-content-only-deploy.txt
+++ b/last-content-only-deploy.txt
@@ -2,7 +2,7 @@ This file is used to trigger Vercel deploys when there are no code changes, only
 
 Here's how it works:
 
-git checkout -b new-branch
+git checkout -b trigger-deploy
 echo `date` >> last-content-only-deploy.txt
 git add last-content-only-deploy.txt
 git commit -m"date last-content-only-deploy.txt"


### PR DESCRIPTION
This to deploy some Labs content changes in Storyblok that @noatamir made and listed in Slack:

- home page: “Making Open Source Sustainable & Access-Centered”
- project page: “Projects we are actively working on, and the key contributions made by current and past Labs team members”
- team page: “We believe inclusion and belonging are fundamental to the success of Labs and the PyData ecosystem”
- blog: “The Labs team shares their news, updates, and knowledge”