### PR TITLE
[BLOG] Add feature image for Scipy 2022 Labs blog

### DIFF
--- a/apps/labs/posts/alt-text-scipy-2022.md
+++ b/apps/labs/posts/alt-text-scipy-2022.md
@@ -4,9 +4,9 @@ author: tony-fast
 published: July 13, 2022
 description: "Announcing the SciPy 2022 Accessibility Awareness Efforts"
 category: [Access-centered]
-# featuredImage:
-#   src: /posts/hello-world-post/featured.png
-#   alt: 'Excellent alt-text describing the featured image'
+featuredImage:
+ src: /posts/ally-scavenger-hunt-post-hero-image.png
+ alt: 'Three screenshots from the digital version of How to Write Alt Text for Scientific Diagrams and Visualization.'
 hero:
  imageSrc: /posts/ally-scavenger-hunt-post-hero-image.png
  imageAlt: 'Three screenshots from the digital version of How to Write Alt Text for Scientific Diagrams and Visualization.'


### PR DESCRIPTION
The feature image was left unspecified, making the tile for the post look bad on the `/blog` page.