### PR TITLE
Add Storyblok content note for #426 fix

### DIFF
--- a/apps/consulting/CHANGELOG.md
+++ b/apps/consulting/CHANGELOG.md
@@ -1,3 +1,11 @@
+Aug 25, 2022
+
+Via Storyblok:
+
+- Fix 'Learn More' links in service areas links at
+  bottom of /data-engineering-mlops
+
+
 July 7, 2022
 
 Via Storyblok:

--- a/apps/consulting/CHANGELOG.md
+++ b/apps/consulting/CHANGELOG.md
@@ -4,6 +4,7 @@ Via Storyblok:
 
 - Fix 'Learn More' links in service areas links at
   bottom of /data-engineering-mlops
+  ([#426](https://github.com/Quansight/Quansight-website/issues/426))
 
 
 July 7, 2022


### PR DESCRIPTION
Adding correct internal link targets for "Learn More" links
at the bottom of the Data Engineering & MLOps services page.

Closes #426.