### PR TITLE
Add Training page; remove Home from header nav

### DIFF
--- a/apps/consulting/CHANGELOG.md
+++ b/apps/consulting/CHANGELOG.md
@@ -1,3 +1,11 @@
+September 21, 2022
+
+Via Storyblok:
+
+- Add "Training" page to site
+- Remove "Home" link from header nav
+- Add "Training" link to header nav
+
 September 13, 2022
 
 Via Storyblok:


### PR DESCRIPTION
The Training page is ready to go live.

Most sites do not include 'Home' explicitly in the header nav, instead using the logo as a 'home' link. As the LLC site is set up with the logo/home link, the 'Home' in the nav is superfluous.
