### PR TITLE
Change bug_report.yml dropdown from 'LLC' to 'Consulting'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
       description: Select as many as needed
       multiple: true
       options:
-        - Quansight LLC
+        - Quansight Consulting
         - Quansight Labs
     validations:
       required: true


### PR DESCRIPTION
Moving away from "LLC" as shorthand for the consulting site