### PR TITLE
MAINT - Release 2022-11-22

### DIFF
--- a/apps/consulting/index.d.ts
+++ b/apps/consulting/index.d.ts
@@ -1,6 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-declare module '*.svg' {
-  const content: any
-  export const ReactComponent: any
-  export default content
+
+declare global {
+  interface Window {
+    gtag: any;
+  }
 }
+
+declare module '*.svg' {
+  const content: any;
+  export const ReactComponent: any;
+  export default content;
+}
+
+export {};

--- a/apps/consulting/pages/_app.tsx
+++ b/apps/consulting/pages/_app.tsx
@@ -12,6 +12,18 @@ function CustomApp({ Component, pageProps }: AppProps): JSX.Element {
       <Meta />
       <Component {...pageProps} />
 
+      {/* These two scripts are included verbatim as per gtag instructions */}
+      <Script
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}`}
+      />
+      <Script id="google-analytics-script" strategy="afterInteractive">
+        {`window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}');`}
+      </Script>
+
       {typeof window !== 'undefined' &&
         window.location.hostname === consultingDomain && (
           // For more info about this script, see note in consulting/next.config.js

--- a/apps/labs/index.d.ts
+++ b/apps/labs/index.d.ts
@@ -1,6 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+declare global {
+  interface Window {
+    gtag: any;
+  }
+}
+
 declare module '*.svg' {
   const content: any;
   export const ReactComponent: any;
   export default content;
 }
+
+export {};

--- a/libs/shared/ui-components/src/Form/Form.tsx
+++ b/libs/shared/ui-components/src/Form/Form.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 
 import { sendFormData, FormValues } from '@quansight/shared/utils';
 import { BOOK_A_CALL_FORM_ID } from '@quansight/shared/utils';
+import { gtag_report_conversion } from '@quansight/shared/utils';
 
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
@@ -35,6 +36,7 @@ export const Form: FC<TFormProps> = (props) => {
   };
 
   const onSubmit = handleSubmit((formValues): void => {
+    gtag_report_conversion();  // null argument so that no page nav happens
     sendFormData(hookUrl, formValues)
       .then(() => setFormStatus(FormStates.Success))
       .catch(() => setFormStatus(FormStates.Failure));

--- a/libs/shared/utils/src/gtag/reportConversion.ts
+++ b/libs/shared/utils/src/gtag/reportConversion.ts
@@ -1,0 +1,15 @@
+// Snippet from https://github.com/Quansight/Quansight-website/issues/404#issuecomment-1248287234
+
+export const gtag_report_conversion = (url?: Location | undefined) => {
+  const callback = function () {
+    if (typeof url != 'undefined') {
+      window.location = url;
+    }
+  };
+
+  window.gtag('event', 'conversion', {
+    send_to: `${process.env['NEXT_PUBLIC_GOOGLE_ANALYTICS']}/${process.env['NEXT_PUBLIC_CONVERSION_LABEL']}`,
+    event_callback: callback,
+  });
+  return false;
+};

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -14,3 +14,5 @@ export * from './constants/bookACallFormID';
 export * from './hooks';
 
 export * from './preview';
+
+export * from './gtag/reportConversion';

--- a/libs/shared/utils/tsconfig.lib.json
+++ b/libs/shared/utils/tsconfig.lib.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["node"]
+    "types": ["node", "@types/gtag.js"]
   },
   "files": [
     "../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@nrwl/workspace": "13.8.4",
         "@testing-library/react": "12.1.3",
         "@testing-library/react-hooks": "7.0.2",
+        "@types/gtag.js": "^0.0.12",
         "@types/jest": "27.4.1",
         "@types/node": "17.0.21",
         "@types/react": "17.0.30",
@@ -11646,6 +11647,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/gtag.js": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
+      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
+      "dev": true
     },
     "node_modules/@types/hast": {
       "version": "2.3.4",
@@ -40849,6 +40856,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/gtag.js": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
+      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
+      "dev": true
     },
     "@types/hast": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@nrwl/workspace": "13.8.4",
     "@testing-library/react": "12.1.3",
     "@testing-library/react-hooks": "7.0.2",
+    "@types/gtag.js": "^0.0.12",
     "@types/jest": "27.4.1",
     "@types/node": "17.0.21",
     "@types/react": "17.0.30",


### PR DESCRIPTION
Changes added in `develop` since last release:

* feat(llc):[QUAN-12]: add global gtag script

* feat(llc):[QUAN-12]: report conversion on form submission

* feat(llc/labs):[QUAN-12]: extend Window interface with gtag property

* feat(llc):[QUAN-12]: pass window.location object to gtag_report_conversion after form validation

* Remove URL from gtag_report_conversion call

We don't want to navigate to a new page as a result of the conversion being reported. This was my (Brian's) mistake, misunderstanding the function of the URL here.

* feat(llc):[QUAN-12]: after cr

* Re-remove argument to gtag_report_conversion()

We don't want the page to navigate anywhere after
the form is submitted. This fix was accidentally reverted in the course of PR review.

* Add sourcing comment for gtag in _app.tsx

Co-authored-by: Brian Skinn <brian.skinn@gmail.com>
