### PR TITLE
[FEAT]: Add pass-through of UTM parameters to Zapier

### DIFF
--- a/apps/consulting/pages/_document.tsx
+++ b/apps/consulting/pages/_document.tsx
@@ -1,19 +1,31 @@
 import { FC } from 'react';
 
 import { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
 
 const Document: FC = () => {
   return (
     <Html lang="en" className="text-[62.5%]">
       <Head>
+        <Script id="session-store-url-params" strategy="beforeInteractive">
+          {`
+            const urlSearchParams = new URLSearchParams(window.location.search);
+            const params = Object.fromEntries(urlSearchParams.entries());
+            for (const param in params) {
+              if (
+                param.toLowerCase().startsWith('gclid') || 
+                param.toLowerCase().startsWith('utm_')
+                ) {
+                  window.sessionStorage.setItem(param, params[param])
+                }
+            }
+          `}
+        </Script>
         <link
           href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400;600;700;800&family=Mukta:wght@400;500;700;800&display=swap"
           rel="stylesheet"
         />
-        <link
-          rel="shortcut icon"
-          href="/favicon.png"
-        />
+        <link rel="shortcut icon" href="/favicon.png" />
       </Head>
       <body>
         <Main />

--- a/apps/consulting/pages/_document.tsx
+++ b/apps/consulting/pages/_document.tsx
@@ -7,15 +7,25 @@ const Document: FC = () => {
   return (
     <Html lang="en" className="text-[62.5%]">
       <Head>
+        {/*
+          This script collects any GCLID and UTM query parameters from incoming
+          traffic and stores them in `sessionStorage`. It uses a 'quansight_'
+          prefix on the names of all stored parameters to reduce the possibility
+          of collision with other sites that might be using sessionStorage for
+          similar purposes.
+
+          Search params approach from https://stackoverflow.com/a/901144/4376000.
+        */}
         <Script id="session-store-url-params" strategy="beforeInteractive">
           {`
             const urlSearchParams = new URLSearchParams(window.location.search);
             const params = Object.fromEntries(urlSearchParams.entries());
             for (const param in params) {
               if (
-                param.toLowerCase().startsWith('gclid') || 
+                param.toLowerCase().startsWith('gclid') ||
                 param.toLowerCase().startsWith('utm_')
                 ) {
+                  // Prefix with 'quansight_' to minimize possible name collisions
                   window.sessionStorage.setItem('quansight_' + param, params[param])
                 }
             }

--- a/apps/consulting/pages/_document.tsx
+++ b/apps/consulting/pages/_document.tsx
@@ -15,6 +15,10 @@ const Document: FC = () => {
           similar purposes.
 
           Search params approach from https://stackoverflow.com/a/901144/4376000.
+          
+          'afterInteractive' strategy chosen here to minimize any reduction of
+          page load speed. It seems unlikely that anything could happen to disrupt
+          the UTM parameters in the `window.location` prior to their capture here.
         */}
         <Script id="session-store-url-params" strategy="afterInteractive">
           {`

--- a/apps/consulting/pages/_document.tsx
+++ b/apps/consulting/pages/_document.tsx
@@ -23,14 +23,13 @@ const Document: FC = () => {
         <Script id="session-store-url-params" strategy="beforeInteractive">
           {`
             const urlSearchParams = new URLSearchParams(window.location.search);
-            const params = Object.fromEntries(urlSearchParams.entries());
-            for (const param in params) {
+            for (const [key, value] of urlSearchParams) {
               if (
                 // param.toLowerCase().startsWith('gclid') ||
                 param.toLowerCase().startsWith('utm_')
                 ) {
                   // Prefix with 'quansight_' to minimize possible name collisions
-                  window.sessionStorage.setItem('quansight_' + param, params[param])
+                  window.sessionStorage.setItem('quansight_' + key, value)
                 }
             }
           `}

--- a/apps/consulting/pages/_document.tsx
+++ b/apps/consulting/pages/_document.tsx
@@ -16,7 +16,7 @@ const Document: FC = () => {
                 param.toLowerCase().startsWith('gclid') || 
                 param.toLowerCase().startsWith('utm_')
                 ) {
-                  window.sessionStorage.setItem(param, params[param])
+                  window.sessionStorage.setItem('quansight_' + param, params[param])
                 }
             }
           `}

--- a/apps/consulting/pages/_document.tsx
+++ b/apps/consulting/pages/_document.tsx
@@ -14,6 +14,10 @@ const Document: FC = () => {
           of collision with other sites that might be using sessionStorage for
           similar purposes.
 
+          The GCLID capture is disabled for now, since we're not sure how
+          extensively we will be running Google Ads, and it simplifies any
+          privacy questions to omit its capture.
+
           Search params approach from https://stackoverflow.com/a/901144/4376000.
         */}
         <Script id="session-store-url-params" strategy="beforeInteractive">
@@ -22,7 +26,7 @@ const Document: FC = () => {
             const params = Object.fromEntries(urlSearchParams.entries());
             for (const param in params) {
               if (
-                param.toLowerCase().startsWith('gclid') ||
+                // param.toLowerCase().startsWith('gclid') ||
                 param.toLowerCase().startsWith('utm_')
                 ) {
                   // Prefix with 'quansight_' to minimize possible name collisions

--- a/apps/consulting/pages/_document.tsx
+++ b/apps/consulting/pages/_document.tsx
@@ -14,22 +14,21 @@ const Document: FC = () => {
           of collision with other sites that might be using sessionStorage for
           similar purposes.
 
-          The GCLID capture is disabled for now, since we're not sure how
-          extensively we will be running Google Ads, and it simplifies any
-          privacy questions to omit its capture.
-
           Search params approach from https://stackoverflow.com/a/901144/4376000.
         */}
-        <Script id="session-store-url-params" strategy="beforeInteractive">
+        <Script id="session-store-url-params" strategy="afterInteractive">
           {`
             const urlSearchParams = new URLSearchParams(window.location.search);
             for (const [key, value] of urlSearchParams) {
               if (
-                // param.toLowerCase().startsWith('gclid') ||
-                param.toLowerCase().startsWith('utm_')
+                /* The GCLID capture is disabled for now, since we're not sure how
+                   extensively we will be running Google Ads, and it simplifies any
+                   privacy questions to omit its capture.
+                */
+                // key.toLowerCase().startsWith('gclid') ||
+                key.toLowerCase().startsWith('utm_')
                 ) {
-                  // Prefix with 'quansight_' to minimize possible name collisions
-                  window.sessionStorage.setItem('quansight_' + key, value)
+                  window.sessionStorage.setItem(key, value);
                 }
             }
           `}

--- a/libs/shared/ui-components/src/Form/Form.tsx
+++ b/libs/shared/ui-components/src/Form/Form.tsx
@@ -3,7 +3,12 @@ import { FC, useState } from 'react';
 import clsx from 'clsx';
 import { useForm } from 'react-hook-form';
 
-import { sendFormData, FormValues } from '@quansight/shared/utils';
+import {
+  sendFormData,
+  FormValues,
+  ParamValues,
+  FormAndParamValues,
+} from '@quansight/shared/utils';
 import { BOOK_A_CALL_FORM_ID } from '@quansight/shared/utils';
 
 import { Button } from '../Button/Button';
@@ -14,7 +19,7 @@ import { FormHeader } from './FormHeader';
 import { FormImage } from './FormImage';
 import { FormSuccess } from './FormSuccess';
 import { FormStates, TFormProps } from './types';
-import { getFormHeader } from './utils';
+import { getFormHeader, getParamValues, combineFormParamValues } from './utils';
 
 export const backgroundStyles = `
   before:absolute before:top-0 before:left-0 before:z-0 before:w-full before:h-full before:bg-gray-50
@@ -35,7 +40,13 @@ export const Form: FC<TFormProps> = (props) => {
   };
 
   const onSubmit = handleSubmit((formValues): void => {
-    sendFormData(hookUrl, formValues)
+    const paramValues: ParamValues = getParamValues();
+    const combinedValues: FormAndParamValues = combineFormParamValues(
+      formValues,
+      paramValues,
+    );
+
+    sendFormData(hookUrl, combinedValues)
       .then(() => setFormStatus(FormStates.Success))
       .catch(() => setFormStatus(FormStates.Failure));
   });

--- a/libs/shared/ui-components/src/Form/Form.tsx
+++ b/libs/shared/ui-components/src/Form/Form.tsx
@@ -6,8 +6,8 @@ import { useForm } from 'react-hook-form';
 import {
   sendFormData,
   FormValues,
-  ParamValues,
-  FormAndParamValues,
+  TrackingParams,
+  FormAndTrackingValues,
 } from '@quansight/shared/utils';
 import { BOOK_A_CALL_FORM_ID } from '@quansight/shared/utils';
 
@@ -19,7 +19,7 @@ import { FormHeader } from './FormHeader';
 import { FormImage } from './FormImage';
 import { FormSuccess } from './FormSuccess';
 import { FormStates, TFormProps } from './types';
-import { getFormHeader, getParamValues, combineFormParamValues } from './utils';
+import { getFormHeader, getTrackingParams } from './utils';
 
 export const backgroundStyles = `
   before:absolute before:top-0 before:left-0 before:z-0 before:w-full before:h-full before:bg-gray-50
@@ -40,11 +40,15 @@ export const Form: FC<TFormProps> = (props) => {
   };
 
   const onSubmit = handleSubmit((formValues): void => {
-    const paramValues: ParamValues = getParamValues();
-    const combinedValues: FormAndParamValues = combineFormParamValues(
-      formValues,
-      paramValues,
-    );
+    const trackingParams: TrackingParams = getTrackingParams();
+    const combinedValues: FormAndTrackingValues = {
+      ...formValues,
+      ...trackingParams,
+    };
+    // const combinedValues: FormAndParamValues = combineFormParamValues(
+    //   formValues,
+    //   paramValues,
+    // );
 
     sendFormData(hookUrl, combinedValues)
       .then(() => setFormStatus(FormStates.Success))

--- a/libs/shared/ui-components/src/Form/Form.tsx
+++ b/libs/shared/ui-components/src/Form/Form.tsx
@@ -45,10 +45,6 @@ export const Form: FC<TFormProps> = (props) => {
       ...formValues,
       ...trackingParams,
     };
-    // const combinedValues: FormAndParamValues = combineFormParamValues(
-    //   formValues,
-    //   paramValues,
-    // );
 
     sendFormData(hookUrl, combinedValues)
       .then(() => setFormStatus(FormStates.Success))

--- a/libs/shared/ui-components/src/Form/utils.ts
+++ b/libs/shared/ui-components/src/Form/utils.ts
@@ -21,12 +21,13 @@ export const getFormHeader = (props: TFormProps, state: FormStates): string => {
 
 /**
  * Retrieves any GCLID & UTM parameters saved to sessionStorage.
+ * GCLID capture disabled for now.
  *
  * @returns {ParamValues} - Encapsulated GCLID/UTM parameters
  */
 export const getParamValues = (): ParamValues => {
   const params: ParamValues = {
-    gclid: sessionStorage.getItem('quansight_gclid') || undefined,
+    // gclid: sessionStorage.getItem('quansight_gclid') || undefined,
     utm_campaign: sessionStorage.getItem('quansight_utm_campaign') || undefined,
     utm_content: sessionStorage.getItem('quansight_utm_content') || undefined,
     utm_medium: sessionStorage.getItem('quansight_utm_medium') || undefined,
@@ -38,6 +39,7 @@ export const getParamValues = (): ParamValues => {
 
 /**
  * Compiles form data and GCLID/UTM data to a common object.
+ * GCLID capture disabled for now.
  *
  * @param formValues {FormValues} - User entered contact form data
  * @param paramValues {ParamValues} - GCLID/UTM parameters retrieved from sessionStorage
@@ -53,7 +55,7 @@ export const combineFormParamValues = (
     phone: formValues.phone,
     company: formValues.company,
     message: formValues.message,
-    gclid: paramValues.gclid,
+    // gclid: paramValues.gclid,
     utm_campaign: paramValues.utm_campaign,
     utm_content: paramValues.utm_content,
     utm_medium: paramValues.utm_medium,

--- a/libs/shared/ui-components/src/Form/utils.ts
+++ b/libs/shared/ui-components/src/Form/utils.ts
@@ -24,11 +24,11 @@ export const getFormHeader = (props: TFormProps, state: FormStates): string => {
 export const getTrackingParams = (): TrackingParams => {
   const params: TrackingParams = {
     // gclid: sessionStorage.getItem('gclid') || undefined,
-    utm_campaign: sessionStorage.getItem('utm_campaign') || undefined,
-    utm_content: sessionStorage.getItem('utm_content') || undefined,
-    utm_medium: sessionStorage.getItem('utm_medium') || undefined,
-    utm_source: sessionStorage.getItem('utm_source') || undefined,
-    utm_term: sessionStorage.getItem('utm_term') || undefined,
+    utm_campaign: sessionStorage.getItem('utm_campaign') || '',
+    utm_content: sessionStorage.getItem('utm_content') || '',
+    utm_medium: sessionStorage.getItem('utm_medium') || '',
+    utm_source: sessionStorage.getItem('utm_source') || '',
+    utm_term: sessionStorage.getItem('utm_term') || '',
   };
   return params;
 };

--- a/libs/shared/ui-components/src/Form/utils.ts
+++ b/libs/shared/ui-components/src/Form/utils.ts
@@ -32,32 +32,3 @@ export const getTrackingParams = (): TrackingParams => {
   };
   return params;
 };
-
-/**
- * Compiles form data and GCLID/UTM data to a common object.
- * GCLID capture disabled for now.
- *
- * @param formValues {FormValues} - User entered contact form data
- * @param paramValues {ParamValues} - GCLID/UTM parameters retrieved from sessionStorage
- * @returns {FormAndParamValues} - Agglomerated form & GCLID/UTM data
- */
-// export const combineFormTrackingValues = (
-//   formValues: FormValues,
-//   paramValues: ParamValues,
-// ): FormAndParamValues => {
-//   const fpvals: FormAndParamValues = {
-//     name: formValues.name,
-//     email: formValues.email,
-//     phone: formValues.phone,
-//     company: formValues.company,
-//     message: formValues.message,
-//     // gclid: paramValues.gclid,
-//     utm_campaign: paramValues.utm_campaign,
-//     utm_content: paramValues.utm_content,
-//     utm_medium: paramValues.utm_medium,
-//     utm_source: paramValues.utm_source,
-//     utm_term: paramValues.utm_term,
-//   };
-
-//   return fpvals;
-// };

--- a/libs/shared/ui-components/src/Form/utils.ts
+++ b/libs/shared/ui-components/src/Form/utils.ts
@@ -20,15 +20,14 @@ export const getFormHeader = (props: TFormProps, state: FormStates): string => {
 };
 
 export const getParamValues = (): ParamValues => {
-  const params: ParamValues = {};
-
-  params.gclid = sessionStorage.getItem('gclid') || undefined;
-  params.utm_campaign = sessionStorage.getItem('utm_campaign') || undefined;
-  params.utm_content = sessionStorage.getItem('utm_content') || undefined;
-  params.utm_medium = sessionStorage.getItem('utm_medium') || undefined;
-  params.utm_source = sessionStorage.getItem('utm_source') || undefined;
-  params.utm_term = sessionStorage.getItem('utm_term') || undefined;
-
+  const params: ParamValues = {
+    gclid: sessionStorage.getItem('quansight_gclid') || undefined,
+    utm_campaign: sessionStorage.getItem('quansight_utm_campaign') || undefined,
+    utm_content: sessionStorage.getItem('quansight_utm_content') || undefined,
+    utm_medium: sessionStorage.getItem('quansight_utm_medium') || undefined,
+    utm_source: sessionStorage.getItem('quansight_utm_source') || undefined,
+    utm_term: sessionStorage.getItem('quansight_utm_term') || undefined,
+  };
   return params;
 };
 

--- a/libs/shared/ui-components/src/Form/utils.ts
+++ b/libs/shared/ui-components/src/Form/utils.ts
@@ -19,6 +19,11 @@ export const getFormHeader = (props: TFormProps, state: FormStates): string => {
   }
 };
 
+/**
+ * Retrieves any GCLID & UTM parameters saved to sessionStorage.
+ *
+ * @returns {ParamValues} - Encapsulated GCLID/UTM parameters
+ */
 export const getParamValues = (): ParamValues => {
   const params: ParamValues = {
     gclid: sessionStorage.getItem('quansight_gclid') || undefined,
@@ -31,6 +36,13 @@ export const getParamValues = (): ParamValues => {
   return params;
 };
 
+/**
+ * Compiles form data and GCLID/UTM data to a common object.
+ *
+ * @param formValues {FormValues} - User entered contact form data
+ * @param paramValues {ParamValues} - GCLID/UTM parameters retrieved from sessionStorage
+ * @returns {FormAndParamValues} - Agglomerated form & GCLID/UTM data
+ */
 export const combineFormParamValues = (
   formValues: FormValues,
   paramValues: ParamValues,

--- a/libs/shared/ui-components/src/Form/utils.ts
+++ b/libs/shared/ui-components/src/Form/utils.ts
@@ -1,8 +1,4 @@
-import {
-  FormValues,
-  FormAndParamValues,
-  ParamValues,
-} from '@quansight/shared/utils';
+import { TrackingParams } from '@quansight/shared/utils';
 
 import { TFormProps, FormStates } from './types';
 
@@ -23,16 +19,16 @@ export const getFormHeader = (props: TFormProps, state: FormStates): string => {
  * Retrieves any GCLID & UTM parameters saved to sessionStorage.
  * GCLID capture disabled for now.
  *
- * @returns {ParamValues} - Encapsulated GCLID/UTM parameters
+ * @returns {TrackingParams} - Encapsulated GCLID/UTM parameters
  */
-export const getParamValues = (): ParamValues => {
-  const params: ParamValues = {
-    // gclid: sessionStorage.getItem('quansight_gclid') || undefined,
-    utm_campaign: sessionStorage.getItem('quansight_utm_campaign') || undefined,
-    utm_content: sessionStorage.getItem('quansight_utm_content') || undefined,
-    utm_medium: sessionStorage.getItem('quansight_utm_medium') || undefined,
-    utm_source: sessionStorage.getItem('quansight_utm_source') || undefined,
-    utm_term: sessionStorage.getItem('quansight_utm_term') || undefined,
+export const getTrackingParams = (): TrackingParams => {
+  const params: TrackingParams = {
+    // gclid: sessionStorage.getItem('gclid') || undefined,
+    utm_campaign: sessionStorage.getItem('utm_campaign') || undefined,
+    utm_content: sessionStorage.getItem('utm_content') || undefined,
+    utm_medium: sessionStorage.getItem('utm_medium') || undefined,
+    utm_source: sessionStorage.getItem('utm_source') || undefined,
+    utm_term: sessionStorage.getItem('utm_term') || undefined,
   };
   return params;
 };
@@ -45,23 +41,23 @@ export const getParamValues = (): ParamValues => {
  * @param paramValues {ParamValues} - GCLID/UTM parameters retrieved from sessionStorage
  * @returns {FormAndParamValues} - Agglomerated form & GCLID/UTM data
  */
-export const combineFormParamValues = (
-  formValues: FormValues,
-  paramValues: ParamValues,
-): FormAndParamValues => {
-  const fpvals: FormAndParamValues = {
-    name: formValues.name,
-    email: formValues.email,
-    phone: formValues.phone,
-    company: formValues.company,
-    message: formValues.message,
-    // gclid: paramValues.gclid,
-    utm_campaign: paramValues.utm_campaign,
-    utm_content: paramValues.utm_content,
-    utm_medium: paramValues.utm_medium,
-    utm_source: paramValues.utm_source,
-    utm_term: paramValues.utm_term,
-  };
+// export const combineFormTrackingValues = (
+//   formValues: FormValues,
+//   paramValues: ParamValues,
+// ): FormAndParamValues => {
+//   const fpvals: FormAndParamValues = {
+//     name: formValues.name,
+//     email: formValues.email,
+//     phone: formValues.phone,
+//     company: formValues.company,
+//     message: formValues.message,
+//     // gclid: paramValues.gclid,
+//     utm_campaign: paramValues.utm_campaign,
+//     utm_content: paramValues.utm_content,
+//     utm_medium: paramValues.utm_medium,
+//     utm_source: paramValues.utm_source,
+//     utm_term: paramValues.utm_term,
+//   };
 
-  return fpvals;
-};
+//   return fpvals;
+// };

--- a/libs/shared/ui-components/src/Form/utils.ts
+++ b/libs/shared/ui-components/src/Form/utils.ts
@@ -1,3 +1,9 @@
+import {
+  FormValues,
+  FormAndParamValues,
+  ParamValues,
+} from '@quansight/shared/utils';
+
 import { TFormProps, FormStates } from './types';
 
 export const getFormHeader = (props: TFormProps, state: FormStates): string => {
@@ -11,4 +17,38 @@ export const getFormHeader = (props: TFormProps, state: FormStates): string => {
     default:
       return title;
   }
+};
+
+export const getParamValues = (): ParamValues => {
+  const params: ParamValues = {};
+
+  params.gclid = sessionStorage.getItem('gclid') || undefined;
+  params.utm_campaign = sessionStorage.getItem('utm_campaign') || undefined;
+  params.utm_content = sessionStorage.getItem('utm_content') || undefined;
+  params.utm_medium = sessionStorage.getItem('utm_medium') || undefined;
+  params.utm_source = sessionStorage.getItem('utm_source') || undefined;
+  params.utm_term = sessionStorage.getItem('utm_term') || undefined;
+
+  return params;
+};
+
+export const combineFormParamValues = (
+  formValues: FormValues,
+  paramValues: ParamValues,
+): FormAndParamValues => {
+  const fpvals: FormAndParamValues = {
+    name: formValues.name,
+    email: formValues.email,
+    phone: formValues.phone,
+    company: formValues.company,
+    message: formValues.message,
+    gclid: paramValues.gclid,
+    utm_campaign: paramValues.utm_campaign,
+    utm_content: paramValues.utm_content,
+    utm_medium: paramValues.utm_medium,
+    utm_source: paramValues.utm_source,
+    utm_term: paramValues.utm_term,
+  };
+
+  return fpvals;
 };

--- a/libs/shared/utils/src/sendFormData/sendFormData.ts
+++ b/libs/shared/utils/src/sendFormData/sendFormData.ts
@@ -1,8 +1,8 @@
-import { FormAndParamValues, SubscriberValues } from './types';
+import { FormAndTrackingValues, SubscriberValues } from './types';
 
 export const sendFormData = (
   url: string,
-  data: FormAndParamValues | SubscriberValues,
+  data: FormAndTrackingValues | SubscriberValues,
 ): Promise<string> => {
   return new Promise<string>(function (resolve, reject) {
     const xhr = new XMLHttpRequest();

--- a/libs/shared/utils/src/sendFormData/sendFormData.ts
+++ b/libs/shared/utils/src/sendFormData/sendFormData.ts
@@ -1,8 +1,8 @@
-import { FormValues, SubscriberValues } from './types';
+import { FormAndParamValues, SubscriberValues } from './types';
 
 export const sendFormData = (
   url: string,
-  data: FormValues | SubscriberValues,
+  data: FormAndParamValues | SubscriberValues,
 ): Promise<string> => {
   return new Promise<string>(function (resolve, reject) {
     const xhr = new XMLHttpRequest();

--- a/libs/shared/utils/src/sendFormData/types.ts
+++ b/libs/shared/utils/src/sendFormData/types.ts
@@ -9,3 +9,26 @@ export type FormValues = {
   company: string;
   message: string;
 };
+
+export type ParamValues = {
+  gclid?: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
+};
+
+export type FormAndParamValues = {
+  name: string;
+  email: string;
+  phone: string;
+  company: string;
+  message: string;
+  gclid?: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
+};

--- a/libs/shared/utils/src/sendFormData/types.ts
+++ b/libs/shared/utils/src/sendFormData/types.ts
@@ -10,8 +10,9 @@ export type FormValues = {
   message: string;
 };
 
+// GCLID capture disabled for now
 export type ParamValues = {
-  gclid?: string;
+  // gclid?: string;
   utm_source?: string;
   utm_medium?: string;
   utm_campaign?: string;
@@ -25,7 +26,7 @@ export type FormAndParamValues = {
   phone: string;
   company: string;
   message: string;
-  gclid?: string;
+  // gclid?: string;
   utm_source?: string;
   utm_medium?: string;
   utm_campaign?: string;

--- a/libs/shared/utils/src/sendFormData/types.ts
+++ b/libs/shared/utils/src/sendFormData/types.ts
@@ -11,7 +11,7 @@ export type FormValues = {
 };
 
 // GCLID capture disabled for now
-export type ParamValues = {
+export type TrackingParams = {
   // gclid?: string;
   utm_source?: string;
   utm_medium?: string;
@@ -20,7 +20,7 @@ export type ParamValues = {
   utm_term?: string;
 };
 
-export type FormAndParamValues = {
+export type FormAndTrackingValues = {
   name: string;
   email: string;
   phone: string;

--- a/libs/shared/utils/src/sendFormData/types.ts
+++ b/libs/shared/utils/src/sendFormData/types.ts
@@ -12,12 +12,12 @@ export type FormValues = {
 
 // GCLID capture disabled for now
 export type TrackingParams = {
-  // gclid?: string;
-  utm_source?: string;
-  utm_medium?: string;
-  utm_campaign?: string;
-  utm_content?: string;
-  utm_term?: string;
+  // gclid: string;
+  utm_source: string;
+  utm_medium: string;
+  utm_campaign: string;
+  utm_content: string;
+  utm_term: string;
 };
 
 export type FormAndTrackingValues = {
@@ -26,10 +26,10 @@ export type FormAndTrackingValues = {
   phone: string;
   company: string;
   message: string;
-  // gclid?: string;
-  utm_source?: string;
-  utm_medium?: string;
-  utm_campaign?: string;
-  utm_content?: string;
-  utm_term?: string;
+  // gclid: string;
+  utm_source: string;
+  utm_medium: string;
+  utm_campaign: string;
+  utm_content: string;
+  utm_term: string;
 };


### PR DESCRIPTION
In order to provide data on the performance of digital marketing campaigns, it's necessary to capture UTM tags on incoming traffic, and store them with the Leads in Pipedrive.

This capture should enable better tracking of when/how marketing campaigns lead to, e.g.:

- Contact form submissions (early-in-pipe/prospect conversions)
- Closed deals (end-of-pipe/client conversions)

If we decide it's necessary, we can also add capture of Google's GCLID, which would enable Offline Conversion Tracking for search ads optimization. GCLID capture is disabled in this PR, however.

---

This PR inserts a script into the header that captures these tags from incoming traffic and stores them in `sessionStorage`. The storage keys on `sessionStorage` are prefixed with `quansight_` to minimize any chance of name collision with other sites that might be performing similar capture.

<img width="709" alt="image" src="https://user-images.githubusercontent.com/11325439/207713847-65f64e26-bf8f-4e5d-9e0c-a660037c0f58.png">

<img width="282" alt="image" src="https://user-images.githubusercontent.com/11325439/207713862-080bad89-56f0-4f37-8bd9-5971d72853fb.png">

Upon contact form submission, the parameters stored in `sessionStorage` are retrieved and bundled with the form-data payload for submission to the Zapier webhook.

<img width="350" alt="image" src="https://user-images.githubusercontent.com/11325439/207714038-5cf017d4-376c-4bfc-beb3-7dc49323a059.png">


If we decide to purchase ads on other platforms that provide similar conversion-tracking/ads-optimization functionality, we may want to add those parameters now or in the future. Otherwise, UTM codes will suffice.

---

Once this code is active on the site, the Zaps will need to be adjusted to pass the parameters into the Leads they create; and then either (a) existing fields in Pipedrive will need to be chosen for storing these parameters, or (b) new fields will need to be created for them in the Pipedrive schema.