### PR TITLE
[FEAT] Add BlogCTAButton blog-only component

### DIFF
--- a/apps/consulting/components/blog-only/BlogCTAButton/BlogCTAButton.tsx
+++ b/apps/consulting/components/blog-only/BlogCTAButton/BlogCTAButton.tsx
@@ -1,10 +1,6 @@
 import { FC } from 'react';
 
-export type TBlogCTAButtonProps = {
-  text: string; // text to display on button
-  url: string; // destination URL for onClick
-  target?: string; // <a> target value (e.g., _blank, _self, ...)
-};
+import { TBlogCTAButtonProps } from './types';
 
 export const BlogCTAButton: FC<TBlogCTAButtonProps> = ({
   text,

--- a/apps/consulting/components/blog-only/BlogCTAButton/BlogCTAButton.tsx
+++ b/apps/consulting/components/blog-only/BlogCTAButton/BlogCTAButton.tsx
@@ -1,0 +1,26 @@
+import { FC } from 'react';
+
+export type TBlogCTAButtonProps = {
+  text: string; // text to display on button
+  url: string; // destination URL for onClick
+  target?: string; // <a> target value (e.g., _blank, _self, ...)
+};
+
+export const BlogCTAButton: FC<TBlogCTAButtonProps> = ({
+  text,
+  url,
+  target,
+}) => {
+  return (
+    <div className="flex justify-center">
+      <button
+        className="py-2 px-8 mt-6 w-fit text-[1.8rem] font-bold leading-[3.7rem] text-white bg-violet"
+        onClick={() => {
+          window.open(url, target);
+        }}
+      >
+        {text} &nbsp; &#9654;
+      </button>
+    </div>
+  );
+};

--- a/apps/consulting/components/blog-only/BlogCTAButton/types.ts
+++ b/apps/consulting/components/blog-only/BlogCTAButton/types.ts
@@ -1,0 +1,5 @@
+export type TBlogCTAButtonProps = {
+  text: string; // text to display on button
+  url: string; // destination URL for onClick
+  target?: string; // <a> target value (e.g., _blank, _self, ...)
+};

--- a/apps/consulting/services/posts/blogAllowedComponents.ts
+++ b/apps/consulting/services/posts/blogAllowedComponents.ts
@@ -8,7 +8,7 @@ import { BlogTable } from '../../components/blog-only/BlogTable/BlogTable';
 
 export const blogAllowedComponents = {
   BlogCTAButton,
-  Picture,
-  CH,
   BlogTable,
+  CH,
+  Picture,
 };

--- a/apps/consulting/services/posts/blogAllowedComponents.ts
+++ b/apps/consulting/services/posts/blogAllowedComponents.ts
@@ -3,9 +3,11 @@ import { CH } from '@code-hike/mdx/dist/components.cjs.js';
 
 import { Picture } from '@quansight/shared/ui-components';
 
+import { BlogCTAButton } from '../../components/blog-only/BlogCTAButton/BlogCTAButton';
 import { BlogTable } from '../../components/blog-only/BlogTable/BlogTable';
 
 export const blogAllowedComponents = {
+  BlogCTAButton,
   Picture,
   CH,
   BlogTable,


### PR DESCRIPTION
The CTA buttons defined for the main part of the website don't style in a way that matches well when placed in the flow of a blog post.

This new `BlogCTAButton` component is intended for use in Consulting blog posts. The styling still needs to be reviewed before the main `feat/QUAN-14...` branch is merged.