### PR TITLE
[CONS BLOG] Apply `<base target="_blank>` to three posts

### DIFF
--- a/apps/consulting/posts/performance-for-image-processing-with-cucim.md
+++ b/apps/consulting/posts/performance-for-image-processing-with-cucim.md
@@ -13,6 +13,8 @@ hero:
   imageAlt: 'Data visualization of Paris city'
 ---
 
+<base target="_blank" />
+
 This post was co-written between Gregory R. Lee & Gigon Bae (NVIDIA).
 
 ## Overview

--- a/apps/consulting/posts/quick-dashboarding-with-panel.md
+++ b/apps/consulting/posts/quick-dashboarding-with-panel.md
@@ -12,6 +12,8 @@ hero:
   imageAlt: 'Data visualization of Paris city'
 ---
 
+<base target="_blank" />
+
 A bespoke, polished data science dashboard can be a beautiful thing for anyone
 looking to make data-driven decisions. And yet, not every project can afford
 setting up elaborate dashboards that cost money and developer time.

--- a/apps/consulting/posts/why-we-are-excited-about-jupyterlab-3-0-dynamic-extensions.md
+++ b/apps/consulting/posts/why-we-are-excited-about-jupyterlab-3-0-dynamic-extensions.md
@@ -181,7 +181,7 @@ development team. Those of us at [Quansight][quansight site] would really like
 to thank the team for all their hard work and thoughtfulness.
 
 Want more Jupyter? Read about Quansight's new project, QHub, in our
-[announcement blog post][qhub post].
+<a href="/post/announcing-qhub" target="_self">announcement blog post</a>.
 
 [jupyterlab docs]: https://jupyterlab.readthedocs.io/
 [quansight site]: https://quansight.com
@@ -203,4 +203,3 @@ Want more Jupyter? Read about Quansight's new project, QHub, in our
 [mybinder]: https://mybinder.org/
 [postbuild]: https://www.npmjs.com/package/postbuild
 [changelog]: https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html#v3-0
-[qhub post]: https://www.quansight.com/post/announcing-qhub

--- a/apps/consulting/posts/why-we-are-excited-about-jupyterlab-3-0-dynamic-extensions.md
+++ b/apps/consulting/posts/why-we-are-excited-about-jupyterlab-3-0-dynamic-extensions.md
@@ -13,6 +13,8 @@ hero:
   imageAlt: 'Data visualization of Paris city'
 ---
 
+<base target="_blank" />
+
 **Co-authors:** Gonzalo Peña-Castellanos, Eric Charles, Eric Kelly
 
 **At [Quansight][quansight site], we’ve been hosting a series of live streams


### PR DESCRIPTION
Backfilling for consistent behavior.

For any links that need to open in the current tab, you have to override the base target by using an explicit `<a href="..." target="_self" />` in the Markdown.

Also convert one link in the JupyterLab 3.0 post to be a site-internal link.