### PR TITLE
Annual report pdf tracking

### DIFF
--- a/apps/labs/next.config.js
+++ b/apps/labs/next.config.js
@@ -61,6 +61,9 @@ const nextConfig = {
     return {
       beforeFiles: [
         {
+          // In the future, this rewrite can be generalized by doing something like
+          // source: '/annual-reports/quansight-labs-annual-report-:year.pdf'
+          // destination: '/api/annual-report.pdf?year=:year'
           source: '/annual-reports/quansight-labs-annual-report-2022.pdf',
           destination: '/api/annual-report.pdf',
         },
@@ -77,7 +80,7 @@ const nextConfig = {
           // you choose something like analytics or plausible, it might get
           // blocked in the future.
           source: '/p7e/js/script.js',
-          destination: 'https://plausible.io/js/script.file-downloads.js',
+          destination: 'https://plausible.io/js/script.js',
         },
         {
           source: '/p7e/api/event',

--- a/apps/labs/next.config.js
+++ b/apps/labs/next.config.js
@@ -59,6 +59,12 @@ const nextConfig = {
     // The conventions of this return value are described in the Next.js docs:
     // https://nextjs.org/docs/api-reference/next.config.js/rewrites
     return {
+      beforeFiles: [
+        {
+          source: '/annual-report.pdf',
+          destination: '/api/annual-report.pdf',
+        },
+      ],
       afterFiles: [
         // These rewrites are checked after pages/public files are checked but
         // before dynamic routes.

--- a/apps/labs/next.config.js
+++ b/apps/labs/next.config.js
@@ -71,7 +71,7 @@ const nextConfig = {
           // you choose something like analytics or plausible, it might get
           // blocked in the future.
           source: '/p7e/js/script.js',
-          destination: 'https://plausible.io/js/script.js',
+          destination: 'https://plausible.io/js/script.file-downloads.js',
         },
         {
           source: '/p7e/api/event',

--- a/apps/labs/next.config.js
+++ b/apps/labs/next.config.js
@@ -61,7 +61,7 @@ const nextConfig = {
     return {
       beforeFiles: [
         {
-          source: '/annual-report.pdf',
+          source: '/annual-reports/quansight-labs-annual-report-2022.pdf',
           destination: '/api/annual-report.pdf',
         },
       ],

--- a/apps/labs/pages/api/annual-report.pdf.ts
+++ b/apps/labs/pages/api/annual-report.pdf.ts
@@ -28,6 +28,8 @@ export default async function handler(req: NextRequest) {
       referrer: req.headers.get('referer'),
     }),
   });
+  // Returning fetch comes from Next.js docs:
+  // https://nextjs.org/docs/api-routes/edge-api-routes#forwarding-headers
   return fetch(
     // TODO change this to the real annual report PDF
     'https://a.storyblok.com/f/152463/x/1752e51fa9/nf-annual-report-2021.pdf',

--- a/apps/labs/pages/api/annual-report.pdf.ts
+++ b/apps/labs/pages/api/annual-report.pdf.ts
@@ -22,7 +22,7 @@ export default async function handler(req: NextRequest) {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      domain: 'gabalafou.com',
+      domain: 'labs.quansight.org',
       name: 'pageview',
       url: req.url,
       referrer: req.headers.get('referer'),

--- a/apps/labs/pages/api/annual-report.pdf.ts
+++ b/apps/labs/pages/api/annual-report.pdf.ts
@@ -25,13 +25,20 @@ export default async function handler(req: NextRequest) {
       domain: 'labs.quansight.org',
       name: 'pageview',
       url: req.url,
+      // A note about spelling: `referrer` on the left (double r) is from the
+      // Plausible spec: https://plausible.io/docs/events-api. `referer` on the
+      // right (single r) is from the HTTP spec. To read more:
+      // https://en.wikipedia.org/wiki/HTTP_referer#Etymology
       referrer: req.headers.get('referer'),
     }),
   });
-  // Returning fetch comes from Next.js docs:
-  // https://nextjs.org/docs/api-routes/edge-api-routes#forwarding-headers
-  return fetch(
-    // TODO change this to the real annual report PDF
+  // A few reasons to use 302 vs 301:
+  // - Ensures that this handler gets called every time that somebody clicks the
+  //   tracking URL for the PDF even if they've clicked it before.
+  // - It signals to search engines and other tech that we do not consider the
+  //   CDN URL for the annual report to be the canonical URL for this resource.
+  return Response.redirect(
     'https://a.storyblok.com/f/152463/x/1752e51fa9/nf-annual-report-2021.pdf',
+    302,
   );
 }

--- a/apps/labs/pages/api/annual-report.pdf.ts
+++ b/apps/labs/pages/api/annual-report.pdf.ts
@@ -12,6 +12,8 @@ export default async function handler(req: NextRequest) {
   req.ip ${req.ip}
   user-agent ${req.headers.get('user-agent')}
   `);
+  // The shape of this fetch comes from the Plausible docs:
+  // https://plausible.io/docs/events-api
   await fetch('https://plausible.io/api/event', {
     method: 'POST',
     headers: {

--- a/apps/labs/pages/api/annual-report.pdf.ts
+++ b/apps/labs/pages/api/annual-report.pdf.ts
@@ -1,0 +1,33 @@
+import type { NextRequest } from 'next/server';
+
+export const config = {
+  runtime: 'experimental-edge',
+};
+
+export default async function handler(req: NextRequest) {
+  // TODO - remove after checking the logs on Vercel
+  console.log(`
+  req.url ${req.url}
+  req.referer ${req.headers.get('referer')}
+  req.ip ${req.ip}
+  user-agent ${req.headers.get('user-agent')}
+  `);
+  await fetch('https://plausible.io/api/event', {
+    method: 'POST',
+    headers: {
+      'User-Agent': req.headers.get('user-agent'),
+      'X-Forwarded-For': req.ip,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      domain: 'gabalafou.com',
+      name: 'pageview',
+      url: req.url,
+      referrer: req.headers.get('referer'),
+    }),
+  });
+  return fetch(
+    // TODO change this to the real annual report PDF
+    'https://a.storyblok.com/f/152463/x/1752e51fa9/nf-annual-report-2021.pdf',
+  );
+}


### PR DESCRIPTION
This PR creates the following URL:

- `labs.quansight.org/annual-reports/quansight-labs-annual-report-2022.pdf`

This URL route is not just a simple file download; it uses Next.js Edge API Routes to:

1. first send tracking data to Plausible,
2. then return the PDF file to the user.

For marketing purposes the URL works just like any other URL. If you want to attach UTM data to the URL, you can do it like this:

- `labs.quansight.org/annual-reports/quansight-labs-annual-report-2022.pdf?utm_source=EthicalAds&utm_campaign=AnnualReport`

Those UTM params will get forwarded to Plausible when the user clicks that link. There is no redirect, by the way—the user clicks the link, Vercel sends a tracking event to Plausible and then serves the user the PDF. If the user were to copy-paste the URL above into their browser, they won't see it change in their address bar. They won't see the request to Plausible (because it happens server side). They'll just see that they entered a URL and got back a PDF.

As far as I can tell, we get all of the same data using this method that we would get with an HTML page EXCEPT for what kind of device the user was using (mobile vs tablet vs desktop). That's because Plausible uses screen size as the heuristic for device type, and the browser doesn't send that info automatically to the server. A normal HTML page on our website, on the other hand, runs the Plausible script, which asks the browser for the screen size and then sends it to Plausible's servers. But so long as we can do without device type info, this approach should be good to go.

For the record, I also considered using a normal URL route—labs.quansight.org/annual-reports/annual-report-2022 (not pdf)—that sends an HTML page to the end user that then automatically redirects to the PDF file. I thought that would be the simplest and most straightforward approach because we could fully leverage the Plausible script. Furthermore, when we eventually do put an HTML landing page at that URL that links rather than redirects to the PDF, we would have continuity across our analytics data (it would be the same `pageview` in Plausible both before and after). And we won't have to go back and change any of the ads or links. However, in order to give the Plausible script enough time to send data, I would have to put a delay on the redirect, and I discovered that [adding a delay to the redirect is an accessibility anti-pattern](https://www.w3.org/WAI/WCAG21/Understanding/change-on-request). There might be ways around it, but it would require me to test, and so this PR seemed like a faster implementation path. Furthermore, I also think it is somewhat of an anti-pattern to have a normal URL redirect to a PDF file, or at the very least, I don't think it represents the highest form of web citizenship, which is what I like to think that Quansight aims for. Which leaves us with one option: a mostly empty landing page that has a _Download PDF_ button that the user can click. But that's also not an ideal user experience in my humble opinion (because it requires two clicks instead of one to get to the content that user wants). The best user experience, as I thought about it, repeatedly took me back to what I have implemented in this PR. The trade-off is a bit more work on our end.