### PR TITLE
Fix path matcher

### DIFF
--- a/apps/labs/next.config.js
+++ b/apps/labs/next.config.js
@@ -35,8 +35,10 @@ const nextConfig = {
         //   Content-Type: application/octet-stream
         //
         // The following rule catches some plain text file types that we link
-        // to, and supplies the text/plain MIME type in the Content-Type header.
-        source: '/:path*(.py|.cpp)',
+        // to, and supplies the text/plain MIME type in the Content-Type header
+        // so that end users can open and view the file directly in their
+        // browser rather than having to first download and save the file.
+        source: '/:path*.(py|cpp)',
         headers: [
           {
             key: 'Content-Type',

--- a/apps/labs/next.config.js
+++ b/apps/labs/next.config.js
@@ -38,6 +38,11 @@ const nextConfig = {
         // to, and supplies the text/plain MIME type in the Content-Type header
         // so that end users can open and view the file directly in their
         // browser rather than having to first download and save the file.
+        //
+        // In the following path matcher string only the stuff in parens is
+        // treated as a regular expression. The period outside the parens is a
+        // literal period. Per the docs:
+        // https://nextjs.org/docs/api-reference/next.config.js/headers#regex-path-matching
         source: '/:path*.(py|cpp)',
         headers: [
           {


### PR DESCRIPTION
Before: match any route that ends in py or cpp
After: match any route that ends in .py or .cpp

This fixes an issue where /blog/re-engineering-cicd-pipelines-for-scipy was returning as plain text rather than as an HTML web page. See:

- https://github.com/Quansight/Quansight-website/pull/648#issuecomment-1412956951

Here's how to test. Visit the following URLs. The first should load as a regular web page. The second and third should load as plain text file (not trigger a download file dialog).

1. https://labs-git-fix-scipy-pipelines-quansight.vercel.app/blog/re-engineering-cicd-pipelines-for-scipy
2. https://labs-git-fix-scipy-pipelines-quansight.vercel.app/posts/cxx-numba-interoperability/cxx2py.py
3. https://labs-git-fix-scipy-pipelines-quansight.vercel.app/posts/cxx-numba-interoperability/cxx2py_libfoo.cpp