### PR TITLE
[CONTENT] Add correct Storyblok asset URL for Labs 2022 report into redirect API 

### DIFF
--- a/apps/labs/pages/api/annual-report.pdf.ts
+++ b/apps/labs/pages/api/annual-report.pdf.ts
@@ -38,7 +38,7 @@ export default async function handler(req: NextRequest) {
   // - It signals to search engines and other tech that we do not consider the
   //   CDN URL for the annual report to be the canonical URL for this resource.
   return Response.redirect(
-    'https://a.storyblok.com/f/152463/x/015c6aa140/labs-annual-report-2022.pdf',
+    'https://a.storyblok.com/f/152463/x/1b6099870a/quansight-labs-annual-report-2022.pdf',
     302,
   );
 }

--- a/apps/labs/pages/api/annual-report.pdf.ts
+++ b/apps/labs/pages/api/annual-report.pdf.ts
@@ -38,7 +38,7 @@ export default async function handler(req: NextRequest) {
   // - It signals to search engines and other tech that we do not consider the
   //   CDN URL for the annual report to be the canonical URL for this resource.
   return Response.redirect(
-    'https://a.storyblok.com/f/152463/x/1752e51fa9/nf-annual-report-2021.pdf',
+    'https://a.storyblok.com/f/152463/x/015c6aa140/labs-annual-report-2022.pdf',
     302,
   );
 }


### PR DESCRIPTION
Replaces the link to the Storyblok asset of the NumFOCUS report PDF used as a placeholder.

Fixes #652.


