### PR TITLE
[MAINT] Back-merge hotfixed content CHANGELOG entries to `develop`

### DIFF
--- a/apps/consulting/CHANGELOG.md
+++ b/apps/consulting/CHANGELOG.md
@@ -1,3 +1,10 @@
+February 15, 2023
+
+Via Storyblok:
+
+- Add Teaser component to homepage with copy and link to Labs 2022
+  Annual Report
+
 January 2, 2023
 
 Via Storyblok:

--- a/apps/labs/CHANGELOG.md
+++ b/apps/labs/CHANGELOG.md
@@ -1,3 +1,10 @@
+February 15, 2023
+
+Via Storyblok:
+
+- Add Teaser component to Labs homepage with copy and link for 2022 Labs
+  Annual Report
+
 September 14, 2022
 
 Via Storyblok:


### PR DESCRIPTION
Back-merge additions to content CHANGELOGs for both sites, for adding the Teaser components linking to the 2022 Labs annual report.

Forgot to add them in the normal course of merges to `develop`.