### PR TITLE
[MAINT] Update redirect to v2 of Labs 2022 report

### DIFF
--- a/apps/labs/pages/api/annual-report.pdf.ts
+++ b/apps/labs/pages/api/annual-report.pdf.ts
@@ -38,7 +38,7 @@ export default async function handler(req: NextRequest) {
   // - It signals to search engines and other tech that we do not consider the
   //   CDN URL for the annual report to be the canonical URL for this resource.
   return Response.redirect(
-    'https://a.storyblok.com/f/152463/x/1b6099870a/quansight-labs-annual-report-2022.pdf',
+    'https://a.storyblok.com/f/152463/x/20372ca74f/quansight-labs-annual-report-2022.pdf',
     302,
   );
 }


### PR DESCRIPTION
The revised version of the Labs 2022 annual report is posted to Storyblok assets. This PR updates the target of the redirect to point to this new version.

Closes #673.