### PR TITLE
Bugfix: remove backticks around inline code in Consulting blog

### DIFF
--- a/apps/consulting/components/BlogArticle/BlogPost/BlogPost.tsx
+++ b/apps/consulting/components/BlogArticle/BlogPost/BlogPost.tsx
@@ -18,7 +18,7 @@ export const BlogPost: FC<TBlogPostProps> = ({ postText }) => {
 
   return (
     <div
-      className="prose-code:px-0 prose-pre:px-0 prose-img:mx-auto prose-figcaption:mt-[2rem] mb-[5rem] min-w-full text-[1.8rem] leading-[2.7rem] text-black prose-a:underline-offset-2 prose-code:bg-transparent prose-pre:bg-transparent prose-code:rounded-lg prose sm:prose-figcaption:mt-0 focus:prose-a:text-violet hover:prose-a:text-violet"
+      className="prose-code:px-0 prose-pre:px-0 prose-img:mx-auto prose-figcaption:mt-[2rem] mb-[5rem] min-w-full text-[1.8rem] leading-[2.7rem] text-black prose-a:underline-offset-2 prose-code:before:content-none prose-code:after:content-none prose-code:bg-transparent prose-pre:bg-transparent prose-code:rounded-lg prose sm:prose-figcaption:mt-0 focus:prose-a:text-violet hover:prose-a:text-violet"
       dangerouslySetInnerHTML={createMarkup(postText)}
     />
   );


### PR DESCRIPTION
For reference: 

- https://github.com/Quansight/Quansight-website/pull/503