### PR TITLE
Release 2023-03-17

### DIFF
--- a/apps/consulting/CHANGELOG.md
+++ b/apps/consulting/CHANGELOG.md
@@ -1,3 +1,9 @@
+March 17, 2023
+
+Via Storyblok:
+
+- Add PyTorch 2022 Contributions Consulting blog post
+
 February 22, 2023
 
 Via Storyblok:

--- a/apps/consulting/components/BlogArticle/BlogPost/BlogPost.tsx
+++ b/apps/consulting/components/BlogArticle/BlogPost/BlogPost.tsx
@@ -18,7 +18,7 @@ export const BlogPost: FC<TBlogPostProps> = ({ postText }) => {
 
   return (
     <div
-      className="prose-code:px-0 prose-pre:px-0 prose-img:mx-auto prose-figcaption:mt-[2rem] mb-[5rem] min-w-full text-[1.8rem] leading-[2.7rem] text-black prose-a:underline-offset-2 prose-code:bg-transparent prose-pre:bg-transparent prose-code:rounded-lg prose sm:prose-figcaption:mt-0 focus:prose-a:text-violet hover:prose-a:text-violet"
+      className="prose-code:px-0 prose-pre:px-0 prose-img:mx-auto prose-figcaption:mt-[2rem] mb-[5rem] min-w-full text-[1.8rem] leading-[2.7rem] text-black prose-a:underline-offset-2 prose-code:before:content-none prose-code:after:content-none prose-code:bg-transparent prose-pre:bg-transparent prose-code:rounded-lg prose sm:prose-figcaption:mt-0 focus:prose-a:text-violet hover:prose-a:text-violet"
       dangerouslySetInnerHTML={createMarkup(postText)}
     />
   );


### PR DESCRIPTION
Merge `develop` into `main`.

Launches the PyTorch 2022 Contributions blog post, and ships a fix to no longer enclose code formatted text on Consulting blogs with explicit backticks.