### PR TITLE
[CONS CONTENT] CHANGELOG updates - starting 24 Mar 2023 

### DIFF
--- a/apps/consulting/CHANGELOG.md
+++ b/apps/consulting/CHANGELOG.md
@@ -1,3 +1,9 @@
+March 27, 2023
+
+Via Storyblok:
+
+- Change homepage hero to be green at all screen sizes
+
 March 24, 2023
 
 Via Storyblok:

--- a/apps/consulting/CHANGELOG.md
+++ b/apps/consulting/CHANGELOG.md
@@ -1,3 +1,9 @@
+March 24, 2023
+
+Via Storyblok:
+
+- Fix glitched asset reference for homepage hero on mobile
+
 March 19, 2023
 
 Via Storyblok:


### PR DESCRIPTION
Something went wrong with the reference to the hero for the mobile view of the homepage.

Reassociating the mobile hero to the desired image should fix the problem (confirmed in preview builds by @lezcano and @pavithraes).

Also, per @irinafumarel, the homepage hero on mobile and tablet should have been the same green as for desktop. With this fixed, closes #340.
