### PR TITLE
On Nebari Services page, fix background color of last block

### DIFF
--- a/apps/consulting/pages/nebari-services.tsx
+++ b/apps/consulting/pages/nebari-services.tsx
@@ -758,8 +758,8 @@ export const NebariServicesPage: FC<TContainerProps> = ({
       </div>
     </section>
 
-    <section className="flex flex-col items-center py-36 px-12 bg-black md:bg-white">
-      <div className="mb-[1em] max-w-[70rem] text-[3rem] font-bold tracking-wide leading-[1.43] text-center text-white md:text-black font-heading">
+    <section className="flex flex-col items-center py-36 px-12 bg-black xl:bg-white">
+      <div className="mb-[1em] max-w-[70rem] text-[3rem] font-bold tracking-wide leading-[1.43] text-center text-white xl:text-black font-heading">
         <h2 className="inline">Learn more</h2> about Nebari deployment,
         training, and support.
       </div>


### PR DESCRIPTION
When the footer is white, the block above it should be black (black background, white foreground), and vice versa. I got the breakpoints wrong on my first pass. This fixes that.

How to test. Go to the Nebari Services page on the preview build. Scroll to the bottom of the page, so that the footer and the block above the footer are visible. Shrink the window below 640 px, then drag it wider than 1280 px, making sure as you drag it that the footer and the block above it have opposite background colors. 

For more info, see [Tailwind breakpoints](https://tailwindcss.com/docs/responsive-design). The Quansight website's footer background color is black above 1280 px, and white below 1280 px.