### PR TITLE
Upgrade tailwind packages

### DIFF
--- a/apps/consulting/components/BlogArticle/BlogHeader/BlogHeader.tsx
+++ b/apps/consulting/components/BlogArticle/BlogHeader/BlogHeader.tsx
@@ -10,7 +10,7 @@ export const BlogHeader: FC<TBlogHeaderProps> = ({
   publishedDate,
   author,
 }) => (
-  <header className="mt-[5.8rem] mb-[7rem] sm:mt-[4.4rem] sm:mb-[4.1rem] xl:mt-[7.1rem]">
+  <header className="mb-[7rem] mt-[5.8rem] sm:mb-[4.1rem] sm:mt-[4.4rem] xl:mt-[7.1rem]">
     <BlogHeaderLink />
     <BlogHeaderPostData postTitle={postTitle} publishedDate={publishedDate} />
     <BlogHeaderAuthor {...author} />

--- a/apps/consulting/components/BlogArticle/BlogHeader/BlogHeaderAuthor.tsx
+++ b/apps/consulting/components/BlogArticle/BlogHeader/BlogHeaderAuthor.tsx
@@ -10,8 +10,8 @@ export const BlogHeaderAuthor: FC<TPostAuthor> = ({
   nickName,
   authorUrl,
 }) => (
-  <section className="flex gap-[1.4rem] justify-start items-center">
-    <div className="overflow-hidden relative w-[4.8rem] h-[4.8rem] rounded-full">
+  <section className="flex items-center justify-start gap-[1.4rem]">
+    <div className="relative h-[4.8rem] w-[4.8rem] overflow-hidden rounded-full">
       <Picture
         imageSrc={avatarSrc}
         imageAlt={fullName}
@@ -20,7 +20,7 @@ export const BlogHeaderAuthor: FC<TPostAuthor> = ({
         objectPosition="center"
       />
     </div>
-    <div className="flex flex-col justify-between items-start">
+    <div className="flex flex-col items-start justify-between">
       <a
         href={authorUrl.url}
         target="_blank"

--- a/apps/consulting/components/BlogArticle/BlogHeader/BlogHeaderLink.tsx
+++ b/apps/consulting/components/BlogArticle/BlogHeader/BlogHeaderLink.tsx
@@ -8,8 +8,8 @@ import HeaderLinkIcon from './assets/headerLinkIcon.svg';
 
 export const BlogHeaderLink: FC = () => (
   <Link href="/library">
-    <a className="flex gap-[1rem] items-center mb-[1.2rem] sm:mt-[1.8rem] justify-left">
-      <div aria-hidden="true" className="relative w-[1rem] h-[1rem] text-black">
+    <a className="justify-left mb-[1.2rem] flex items-center gap-[1rem] sm:mt-[1.8rem]">
+      <div aria-hidden="true" className="relative h-[1rem] w-[1rem] text-black">
         <Picture
           imageSrc={HeaderLinkIcon}
           imageAlt="Decorative"

--- a/apps/consulting/components/BlogArticle/BlogHeader/BlogHeaderPostData.tsx
+++ b/apps/consulting/components/BlogArticle/BlogHeader/BlogHeaderPostData.tsx
@@ -7,7 +7,7 @@ export const BlogHeaderPostData: FC<TBlogHeaderPostDataProps> = ({
   publishedDate,
 }) => (
   <section className="mb-[1.2rem] lg:mb-[3.7rem]">
-    <h2 className="text-[3rem] font-extrabold leading-[5.3rem] sm:mb-[5.1rem] sm:text-[4.8rem] font-heading text-violet">
+    <h2 className="font-heading text-violet text-[3rem] font-extrabold leading-[5.3rem] sm:mb-[5.1rem] sm:text-[4.8rem]">
       {postTitle}
     </h2>
     {publishedDate && (

--- a/apps/consulting/components/BlogArticle/BlogMoreArticles/BlogMoreArticles.tsx
+++ b/apps/consulting/components/BlogArticle/BlogMoreArticles/BlogMoreArticles.tsx
@@ -7,11 +7,11 @@ import { TBlogMoreArticlesProps } from '../types';
 export const BlogMoreArticles: FC<TBlogMoreArticlesProps> = ({
   featuredPosts,
 }) => (
-  <section className="px-[2rem] pt-[10rem] mx-auto mb-[2rem] border-t border-t-gray-100 sm:px-[6rem] sm:mb-[6rem] lg:px-[10rem] xl:px-[25rem] xl:mb-[18rem] max-w-layout">
-    <h3 className="mb-[5rem] text-[1.9rem] font-bold leading-[2.7rem] text-center text-black">
+  <section className="max-w-layout mx-auto mb-[2rem] border-t border-t-gray-100 px-[2rem] pt-[10rem] sm:mb-[6rem] sm:px-[6rem] lg:px-[10rem] xl:mb-[18rem] xl:px-[25rem]">
+    <h3 className="mb-[5rem] text-center text-[1.9rem] font-bold leading-[2.7rem] text-black">
       More articles from our Library
     </h3>
-    <ul className="flex flex-col gap-[3.6rem] justify-between items-center sm:flex-row sm:gap-[2rem]">
+    <ul className="flex flex-col items-center justify-between gap-[3.6rem] sm:flex-row sm:gap-[2rem]">
       {featuredPosts.map((tile) => (
         <Tile key={tile.key} {...tile} tileVariant={TileVariant.Blog} />
       ))}

--- a/apps/consulting/components/Board/Board.tsx
+++ b/apps/consulting/components/Board/Board.tsx
@@ -16,15 +16,15 @@ export const Board: FC<TBoardProps> = ({
   button,
 }) => {
   return (
-    <section className="text-black bg-transparent">
-      <div className="relative py-24 px-[2.4rem] mx-auto sm:text-center md:py-48 md:px-16 xl:px-48 xl:pt-[6.8rem] xl:pb-40 max-w-layout">
+    <section className="bg-transparent text-black">
+      <div className="max-w-layout relative mx-auto px-[2.4rem] py-24 sm:text-center md:px-16 md:py-48 xl:px-48 xl:pb-40 xl:pt-[6.8rem]">
         <HeaderDecoration />
         <ButtonDecoration />
-        <h2 className="text-[4rem] font-extrabold tracking-[0.02em] leading-[5rem] sm:text-[4.8rem] text-violet font-heading">
+        <h2 className="text-violet font-heading text-[4rem] font-extrabold leading-[5rem] tracking-[0.02em] sm:text-[4.8rem]">
           {title}
         </h2>
         <div
-          className="flex flex-col gap-8 mt-[2.8rem] mr-[5.5rem] mb-[4.3rem] text-[1.8rem] leading-[2.2rem] sm:gap-12 sm:mt-28 sm:mr-0 sm:mb-[6rem] lg:mx-36  xl:mt-[3.6rem]"
+          className="mb-[4.3rem] mr-[5.5rem] mt-[2.8rem] flex flex-col gap-8 text-[1.8rem] leading-[2.2rem] sm:mb-[6rem] sm:mr-0 sm:mt-28 sm:gap-12 lg:mx-36  xl:mt-[3.6rem]"
           dangerouslySetInnerHTML={createMarkup(description)}
         />
         <div className="grid grid-cols-1 sm:grid-cols-3 sm:gap-[0.5px] sm:bg-white xl:gap-[1px]">
@@ -35,7 +35,7 @@ export const Board: FC<TBoardProps> = ({
             const firstIndexLastRow = (numberOfRows - 1) * numberOfColumns;
             const isLastRow = index >= firstIndexLastRow;
             const classNameBorder = clsx(
-              'border-b-[0.5px] last:border-b-0 sm:border-r-[0.5px] xl:border-r-[1px] xl:border-b-[1px] sm-flex border-violet',
+              'sm-flex border-violet border-b-[0.5px] last:border-b-0 sm:border-r-[0.5px] xl:border-b-[1px] xl:border-r-[1px]',
               isRightColumn && 'sm:border-r-0 xl:border-r-0',
               isLastRow && 'sm:border-b-0 xl:border-b-0',
             );

--- a/apps/consulting/components/Board/BoardButton.tsx
+++ b/apps/consulting/components/Board/BoardButton.tsx
@@ -14,7 +14,7 @@ const BoardButton: FC<TBoardButtonProps & { classNameBorder: string }> = ({
   return (
     <div
       className={clsx(
-        'z-10 mx-auto mt-[6.5rem] sm:flex sm:justify-center sm:items-center sm:mx-0 sm:mt-0',
+        'z-10 mx-auto mt-[6.5rem] sm:mx-0 sm:mt-0 sm:flex sm:items-center sm:justify-center',
         classNameBorder,
       )}
     >

--- a/apps/consulting/components/Board/BoardItem.tsx
+++ b/apps/consulting/components/Board/BoardItem.tsx
@@ -17,7 +17,7 @@ const BoardItem: FC<TBoardItemProps & { classNameBorder: string }> = ({
   return (
     <div
       className={clsx(
-        'flex flex-col pt-[2.8rem] pb-[4.1rem] text-center sm:pt-[4.2rem]',
+        'flex flex-col pb-[4.1rem] pt-[2.8rem] text-center sm:pt-[4.2rem]',
         classNameBorder,
       )}
     >
@@ -33,10 +33,10 @@ const BoardItem: FC<TBoardItemProps & { classNameBorder: string }> = ({
               priority
             />
           </div>
-          <div className="text-[2.2rem] font-extrabold leading-[3rem] sm:mt-[2.8rem] sm:mb-[2.2rem] xl:mt-[3.6rem] xl:mb-[2.2rem] font-heading">
+          <div className="font-heading text-[2.2rem] font-extrabold leading-[3rem] sm:mb-[2.2rem] sm:mt-[2.8rem] xl:mb-[2.2rem] xl:mt-[3.6rem]">
             {title}
           </div>
-          <div className="flex gap-3 justify-center items-center mx-auto w-auto text-[1.6rem] font-bold leading-[3.7rem]">
+          <div className="mx-auto flex w-auto items-center justify-center gap-3 text-[1.6rem] font-bold leading-[3.7rem]">
             {linkTitle}
             <Picture
               imageSrc="/board/board-btn-arrow.svg"

--- a/apps/consulting/components/Board/decorations/ButtonDecoration.tsx
+++ b/apps/consulting/components/Board/decorations/ButtonDecoration.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { Picture } from '@quansight/shared/ui-components';
 
 export const ButtonDecoration: FC = () => (
-  <div className="hidden absolute top-[85%] right-[5%] w-[37.1rem] h-[22.5rem] lg:block xl:top-[77%] xl:right-[2%]">
+  <div className="absolute right-[5%] top-[85%] hidden h-[22.5rem] w-[37.1rem] lg:block xl:right-[2%] xl:top-[77%]">
     <Picture
       imageSrc="/board/board-btn-icon.svg"
       imageAlt=""

--- a/apps/consulting/components/Board/decorations/HeaderDecoration.tsx
+++ b/apps/consulting/components/Board/decorations/HeaderDecoration.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { Picture } from '@quansight/shared/ui-components';
 
 export const HeaderDecoration: FC = () => (
-  <div className="hidden absolute top-[6%] left-[6%] w-[16.6rem] h-[12.5rem] lg:block xl:top-[15%] xl:left-[2%]">
+  <div className="absolute left-[6%] top-[6%] hidden h-[12.5rem] w-[16.6rem] lg:block xl:left-[2%] xl:top-[15%]">
     <Picture
       imageSrc="/board/board-header-icon.svg"
       imageAlt=""

--- a/apps/consulting/components/BoardList/BoardList.tsx
+++ b/apps/consulting/components/BoardList/BoardList.tsx
@@ -11,11 +11,11 @@ export const BoardList: FC<TBoardListProps> = ({
   linkUrl,
 }) => {
   return (
-    <section className="grid grid-cols-1 gap-x-[2rem] px-[3rem] mx-auto mt-[2.5rem] md:px-[13rem] lg:grid-cols-2 lg:mt-[5rem] max-w-layout">
+    <section className="max-w-layout mx-auto mt-[2.5rem] grid grid-cols-1 gap-x-[2rem] px-[3rem] md:px-[13rem] lg:mt-[5rem] lg:grid-cols-2">
       {grid.map((props) => (
         <BoardListItem {...props} key={props._uid} />
       ))}
-      <div className="flex justify-center items-center lg:justify-start lg:items-start lg:mt-[6rem] lg:ml-[12rem] lg:w-[29rem]">
+      <div className="flex items-center justify-center lg:ml-[12rem] lg:mt-[6rem] lg:w-[29rem] lg:items-start lg:justify-start">
         <ButtonLink
           isFull
           isTriangle

--- a/apps/consulting/components/BoardList/BoardListItem.tsx
+++ b/apps/consulting/components/BoardList/BoardListItem.tsx
@@ -19,7 +19,7 @@ const BoardListItem: FC<TBoardListItemProps> = ({
     lg:flex-row lg:items-start
   "
   >
-    <div className="relative w-full h-[9rem] lg:w-1/3 lg:min-w-[9rem] lg:text-right">
+    <div className="relative h-[9rem] w-full lg:w-1/3 lg:min-w-[9rem] lg:text-right">
       <Picture
         imageSrc={imageSrc}
         imageAlt={imageAlt}
@@ -27,11 +27,11 @@ const BoardListItem: FC<TBoardListItemProps> = ({
         objectFit="contain"
       />
     </div>
-    <div className="mt-[1.5rem] mb-[4.4rem] lg:mt-0">
+    <div className="mb-[4.4rem] mt-[1.5rem] lg:mt-0">
       <h3
         className="
-        text-[2.2rem] font-extrabold leading-[3rem] text-center lg:pl-[3rem]
-        lg:mb-[2.5rem] lg:text-left font-heading
+        font-heading text-center text-[2.2rem] font-extrabold leading-[3rem]
+        lg:mb-[2.5rem] lg:pl-[3rem] lg:text-left
       "
       >
         {title}
@@ -39,7 +39,7 @@ const BoardListItem: FC<TBoardListItemProps> = ({
       {text && (
         <p
           className="
-          mb-[0.5rem] text-[1.6rem] leading-[2.7rem] text-center
+          mb-[0.5rem] text-center text-[1.6rem] leading-[2.7rem]
           lg:px-[3rem] lg:text-left
           xl:pr-[10rem]
         "

--- a/apps/consulting/components/Carousel/CarouselItem.tsx
+++ b/apps/consulting/components/Carousel/CarouselItem.tsx
@@ -19,7 +19,7 @@ export const CarouselItem: FC<TCarouselItemProps> = ({
 
   return (
     <div className="flex flex-col sm:flex-row">
-      <div className="relative w-full h-[22rem] sm:h-[32.7rem]">
+      <div className="relative h-[22rem] w-full sm:h-[32.7rem]">
         <Picture
           imageSrc={imageSrc}
           imageAlt={imageAlt}
@@ -29,13 +29,13 @@ export const CarouselItem: FC<TCarouselItemProps> = ({
           priority
         />
       </div>
-      <div className="flex flex-col pt-[4.1rem] min-h-[27.6rem] text-center text-white sm:basis-[30rem] sm:px-[3.7rem] sm:pb-[4.6rem] sm:min-h-[32.7rem] sm:text-left bg-violet">
+      <div className="bg-violet flex min-h-[27.6rem] flex-col pt-[4.1rem] text-center text-white sm:min-h-[32.7rem] sm:basis-[30rem] sm:px-[3.7rem] sm:pb-[4.6rem] sm:text-left">
         <div>
-          <p className="text-[1.6rem] font-normal leading-[3rem] capitalize">
+          <p className="text-[1.6rem] font-normal capitalize leading-[3rem]">
             {postType}
           </p>
           <LibraryLink link={link} tabIndex={swiperSlide.isActive ? 0 : -1}>
-            <h3 className="text-[3rem] font-extrabold leading-[3.7rem] sm:w-[22.7rem] font-heading">
+            <h3 className="font-heading text-[3rem] font-extrabold leading-[3.7rem] sm:w-[22.7rem]">
               {title}
             </h3>
           </LibraryLink>

--- a/apps/consulting/components/Carousel/CarouselPagination.tsx
+++ b/apps/consulting/components/Carousel/CarouselPagination.tsx
@@ -10,11 +10,11 @@ export const CarouselPagination: FC<TCarouselPaginationProps> = ({
   const swiper = useSwiper();
 
   return (
-    <div className="flex gap-4 justify-center items-center py-1 mt-[8.8rem] sm:mt-[1.1rem]">
+    <div className="mt-[8.8rem] flex items-center justify-center gap-4 py-1 sm:mt-[1.1rem]">
       {[...Array(slidesLength).keys()].map((slideIndex) => (
         <button
           aria-label={`Go to slide ${slideIndex + 1}`}
-          className={`w-4 h-4 rounded-full ${
+          className={`h-4 w-4 rounded-full ${
             currentSlide === slideIndex ? 'bg-pink' : 'bg-gray-100'
           }`}
           key={slideIndex}

--- a/apps/consulting/components/CenteredIntro/CenteredIntro.tsx
+++ b/apps/consulting/components/CenteredIntro/CenteredIntro.tsx
@@ -6,11 +6,11 @@ export const CenteredIntro: FC<TCenteredIntroProps> = ({
   title,
   description,
 }) => (
-  <section className="py-[7.4rem] px-8 mx-auto max-w-layout">
-    <h2 className="mb-[1.9rem] text-[4rem] font-extrabold leading-[4.9rem] text-center sm:mb-[2.5rem] sm:text-[4.8rem] font-heading text-violet">
+  <section className="max-w-layout mx-auto px-8 py-[7.4rem]">
+    <h2 className="font-heading text-violet mb-[1.9rem] text-center text-[4rem] font-extrabold leading-[4.9rem] sm:mb-[2.5rem] sm:text-[4.8rem]">
       {title}
     </h2>
-    <p className="mx-auto max-w-[57rem] text-[2rem] font-normal leading-[3rem] text-center sm:text-[2.2rem]">
+    <p className="mx-auto max-w-[57rem] text-center text-[2rem] font-normal leading-[3rem] sm:text-[2.2rem]">
       {description}
     </p>
   </section>

--- a/apps/consulting/components/Columns/Column/Column.tsx
+++ b/apps/consulting/components/Columns/Column/Column.tsx
@@ -19,17 +19,17 @@ export const Column: FC<TColumnComponentProps> = ({
   variant === ColumnsVariant.Tiles ? (
     <div
       className={clsx(
-        'flex flex-col mb-[3.5rem] md:w-1/3',
+        'mb-[3.5rem] flex flex-col md:w-1/3',
         variant === ColumnsVariant.Tiles &&
-          `py-[3.5rem] px-[2rem] shadow-[0_4px_14px_rgba(0,0,0,.11)]
+          `px-[2rem] py-[3.5rem] shadow-[0_4px_14px_rgba(0,0,0,.11)]
       lg:px-[3rem] lg:pt-[6.4rem]`,
       )}
     >
       <ColumnImage variant={variant} imageSrc={imageSrc} imageAlt={imageAlt} />
       <h3
         className="
-        my-[1.8rem] text-[2.7rem] font-extrabold leading-[3.5rem] text-black lg:mt-[2.6rem]
-        font-heading
+        font-heading my-[1.8rem] text-[2.7rem] font-extrabold leading-[3.5rem] text-black
+        lg:mt-[2.6rem]
       "
       >
         {title}
@@ -42,8 +42,8 @@ export const Column: FC<TColumnComponentProps> = ({
       <ColumnImage variant={variant} imageSrc={imageSrc} imageAlt={imageAlt} />
       <h3
         className="
-        my-[1.8rem] text-[2.7rem] font-extrabold leading-[3.5rem] text-black lg:mt-[2.6rem]
-        font-heading
+        font-heading my-[1.8rem] text-[2.7rem] font-extrabold leading-[3.5rem] text-black
+        lg:mt-[2.6rem]
       "
       >
         {title}

--- a/apps/consulting/components/Columns/Column/ColumnLink.tsx
+++ b/apps/consulting/components/Columns/Column/ColumnLink.tsx
@@ -7,7 +7,7 @@ import { TColumnLinkProps } from './types';
 export const ColumnLink: FC<TColumnLinkProps> = ({ linkText, linkUrl }) => {
   if (linkText && linkUrl) {
     return (
-      <div className="mt-[1rem] ml-[-3rem] lg:mt-[4rem]">
+      <div className="ml-[-3rem] mt-[1rem] lg:mt-[4rem]">
         <ButtonLink
           url={linkUrl}
           text={linkText}

--- a/apps/consulting/components/Columns/Columns.tsx
+++ b/apps/consulting/components/Columns/Columns.tsx
@@ -8,8 +8,8 @@ import { ColumnsVariant, TColumnsProps } from './types';
 export const Columns: FC<TColumnsProps> = ({ variant, columns }) => (
   <section
     className={clsx(
-      'px-[3.5rem] my-[2.4rem] mx-auto max-w-layout',
-      'md:grid md:grid-rows-[repeat(3,_min-content)] md:grid-flow-col md:gap-x-[2rem]',
+      'max-w-layout mx-auto my-[2.4rem] px-[3.5rem]',
+      'md:grid md:grid-flow-col md:grid-rows-[repeat(3,_min-content)] md:gap-x-[2rem]',
       'lg:px-[13rem]',
       variant === ColumnsVariant.Columns && 'lg:gap-x-[7.5rem]',
       variant === ColumnsVariant.Tiles && 'lg:flex lg:gap-x-[3.4rem]',

--- a/apps/consulting/components/FeatureArticle/FeatureArticle.tsx
+++ b/apps/consulting/components/FeatureArticle/FeatureArticle.tsx
@@ -14,11 +14,11 @@ export const FeatureArticle: FC<TFeatureArticleProps> = ({
   decorationAlt,
 }) => {
   return (
-    <article className="grid grid-rows-[auto,auto,auto] gap-x-12 gap-y-14 py-24 pr-20 pl-8 mx-auto sm:grid-cols-[1fr,1fr] sm:grid-rows-[auto,1fr] sm:px-16 lg:grid-cols-[3fr,2fr] lg:px-[13rem] xl:grid-cols-[6fr,5fr] max-w-layout">
-      <h2 className="text-[4rem] font-extrabold leading-[4.8rem] text-left lg:text-[4.8rem] text-violet font-heading">
+    <article className="max-w-layout mx-auto grid grid-rows-[auto,auto,auto] gap-x-12 gap-y-14 py-24 pl-8 pr-20 sm:grid-cols-[1fr,1fr] sm:grid-rows-[auto,1fr] sm:px-16 lg:grid-cols-[3fr,2fr] lg:px-[13rem] xl:grid-cols-[6fr,5fr]">
+      <h2 className="text-violet font-heading text-left text-[4rem] font-extrabold leading-[4.8rem] lg:text-[4.8rem]">
         {title}
       </h2>
-      <div className="self-center my-24 sm:row-span-2 sm:my-0">
+      <div className="my-24 self-center sm:row-span-2 sm:my-0">
         {decorationSrc && decorationAlt && (
           <div className="relative h-36 sm:h-44">
             <Picture

--- a/apps/consulting/components/Features/Feature.tsx
+++ b/apps/consulting/components/Features/Feature.tsx
@@ -7,9 +7,9 @@ import { TFeatureProps } from './types';
 const Feature: FC<TFeatureProps> = ({ title, text, imageSrc, imageAlt }) => (
   <li
     className="
-      pt-[2rem] pb-[5rem] text-center last:border-0 border-b
-      border-white
-      lg:px-[5rem] lg:pb-[13rem] lg:w-1/3 lg:border-r lg:border-b-0
+      border-b border-white pb-[5rem] pt-[2rem] text-center
+      last:border-0
+      lg:w-1/3 lg:border-b-0 lg:border-r lg:px-[5rem] lg:pb-[13rem]
       xl:px-[11rem]
     "
   >
@@ -23,8 +23,8 @@ const Feature: FC<TFeatureProps> = ({ title, text, imageSrc, imageAlt }) => (
     </div>
     <h3
       className="
-        my-[1.5rem] text-[2.2rem] font-extrabold leading-[3rem] text-white uppercase lg:mt-[4rem]
-        lg:mb-[2rem] font-heading
+        font-heading my-[1.5rem] text-[2.2rem] font-extrabold uppercase leading-[3rem] text-white
+        lg:mb-[2rem] lg:mt-[4rem]
       "
     >
       {title}

--- a/apps/consulting/components/Features/Features.tsx
+++ b/apps/consulting/components/Features/Features.tsx
@@ -5,18 +5,18 @@ import { TFeaturesProps } from './types';
 
 export const Features: FC<TFeaturesProps> = ({ title, columns }) => {
   return (
-    <section className="px-[2rem] pt-[6.2rem] lg:px-0 lg:pt-[8.8rem] xl:px-[5rem] bg-violet">
+    <section className="bg-violet px-[2rem] pt-[6.2rem] lg:px-0 lg:pt-[8.8rem] xl:px-[5rem]">
       {title && (
         <h2
           className="
-            mx-auto max-w-[120rem] text-[4rem] font-extrabold leading-[5.1rem] text-center text-white 
+            mx-auto max-w-[120rem] text-center text-[4rem] font-extrabold leading-[5.1rem] text-white 
             lg:mb-[9.3rem] lg:text-[4.8rem]
           "
         >
           {title}
         </h2>
       )}
-      <ul className="flex flex-col mx-auto lg:flex-row max-w-layout">
+      <ul className="max-w-layout mx-auto flex flex-col lg:flex-row">
         {columns.map((props) => (
           <Feature {...props} key={props._uid} />
         ))}

--- a/apps/consulting/components/Filters/FilterMenu/FilterMenu.tsx
+++ b/apps/consulting/components/Filters/FilterMenu/FilterMenu.tsx
@@ -56,22 +56,22 @@ export const FilterMenu: FC<TFilterMenuProps> = ({
         aria-controls="filters"
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
         className={clsx(
-          'relative py-[0.8rem] px-[1.2rem] w-full text-[1.4rem]  font-normal leading-[3rem] text-center uppercase bg-gray-200 border-2 border-gray-300 sm:w-[26rem]',
+          'relative w-full border-2 border-gray-300 bg-gray-200  px-[1.2rem] py-[0.8rem] text-center text-[1.4rem] font-normal uppercase leading-[3rem] sm:w-[26rem]',
           isDropdownOpen ? 'border-b-transparent' : 'border-b-gray-300',
           filterMenuVariant === FilterMenuVariant.Type
             ? 'sm:hidden'
-            : 'sm:flex sm:gap-0 sm:justify-between sm:items-center',
+            : 'sm:flex sm:items-center sm:justify-between sm:gap-0',
         )}
       >
         {currentMenuName}
         <span
           className={clsx(
-            'inline-block absolute top-1/2 right-[1rem] w-0 h-0 border-x-8 border-t-8 border-x-transparent translate-y-[-50%] border-x-solid border-l-solid',
+            'border-x-solid border-l-solid absolute right-[1rem] top-1/2 inline-block h-0 w-0 translate-y-[-50%] border-x-8 border-t-8 border-x-transparent',
             isDropdownOpen
-              ? '-rotate-180 border-violet'
-              : 'border-gray-300 rotate-0',
+              ? 'border-violet -rotate-180'
+              : 'rotate-0 border-gray-300',
             filterMenuVariant === FilterMenuVariant.Category &&
-              'sm:relative sm:top-0 sm:right-0 sm:translate-y-none',
+              'sm:translate-y-none sm:relative sm:right-0 sm:top-0',
           )}
         />
       </button>
@@ -79,14 +79,14 @@ export const FilterMenu: FC<TFilterMenuProps> = ({
         <ul
           id="filters"
           className={clsx(
-            'absolute top-[-.2rem] z-20 px-[1.2rem] pb-[0.8rem] w-full bg-gray-200 border-x-2 border-b-2 border-gray-300',
+            'absolute top-[-.2rem] z-20 w-full border-x-2 border-b-2 border-gray-300 bg-gray-200 px-[1.2rem] pb-[0.8rem]',
             isDropdownOpen
               ? 'block'
               : filterMenuVariant === FilterMenuVariant.Type
-              ? 'hidden sm:block sm:relative'
+              ? 'hidden sm:relative sm:block'
               : 'hidden',
             filterMenuVariant === FilterMenuVariant.Type &&
-              'sm:flex sm:gap-[2rem] sm:justify-start sm:items-center sm:px-0 sm:pb-0 sm:bg-transparent sm:border-none',
+              'sm:flex sm:items-center sm:justify-start sm:gap-[2rem] sm:border-none sm:bg-transparent sm:px-0 sm:pb-0',
           )}
         >
           <FilterMenuItem

--- a/apps/consulting/components/Filters/FilterMenu/FilterMenuItem.tsx
+++ b/apps/consulting/components/Filters/FilterMenu/FilterMenuItem.tsx
@@ -13,7 +13,7 @@ export const FilterMenuItem: FC<TFilterMenuItemProps> = ({
   <li>
     <button
       className={clsx(
-        'w-full text-[1.4rem] font-normal leading-[3rem] text-left uppercase',
+        'w-full text-left text-[1.4rem] font-normal uppercase leading-[3rem]',
         menuDataCurrent === menuDataItemValue ? 'text-pink' : 'text:black',
       )}
       onClick={() => onFilterChange(menuDataItemValue)}

--- a/apps/consulting/components/Filters/Filters.tsx
+++ b/apps/consulting/components/Filters/Filters.tsx
@@ -42,7 +42,7 @@ export const Filters: FC<TFiltersProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-[2rem] justify-between items-center pb-[5.2rem] w-full sm:flex-row sm:gap-[5rem]">
+    <div className="flex w-full flex-col items-center justify-between gap-[2rem] pb-[5.2rem] sm:flex-row sm:gap-[5rem]">
       {/*
       We're removing the type filter until we have content of other types. Right now, we just have blog-type content.
        <FilterMenu

--- a/apps/consulting/components/IntertwinedArticle/IntertwinedArticle.tsx
+++ b/apps/consulting/components/IntertwinedArticle/IntertwinedArticle.tsx
@@ -11,8 +11,8 @@ export const IntertwinedArticle: FC<TIntertwinedArticleProps> = ({
   footer,
 }) => {
   return (
-    <article className="py-[5.8rem] px-12 mx-auto sm:px-[4.8rem] xl:px-[18.5rem] max-w-layout">
-      <h2 className="mb-[3.6rem] text-[4rem] font-extrabold leading-[4.9rem] sm:mb-[6.4rem] sm:text-[4.8rem] sm:text-center xl:mb-32 font-heading text-violet">
+    <article className="max-w-layout mx-auto px-12 py-[5.8rem] sm:px-[4.8rem] xl:px-[18.5rem]">
+      <h2 className="font-heading text-violet mb-[3.6rem] text-[4rem] font-extrabold leading-[4.9rem] sm:mb-[6.4rem] sm:text-center sm:text-[4.8rem] xl:mb-32">
         {title}
       </h2>
       {sections.map((props) => (

--- a/apps/consulting/components/IntertwinedArticle/IntertwinedArticleItem.tsx
+++ b/apps/consulting/components/IntertwinedArticle/IntertwinedArticleItem.tsx
@@ -12,12 +12,12 @@ export const IntertwinedArticleItem: FC<TIntertwinedArticleItemProps> = ({
 }) => {
   const [imageSizes, setImageSizes] = useState({ width: 0, height: 0 });
   return (
-    <section className="flex flex-col-reverse gap-16 justify-center items-center mb-16 sm:flex-row sm:odd:flex-row-reverse sm:gap-32">
+    <section className="mb-16 flex flex-col-reverse items-center justify-center gap-16 sm:flex-row sm:gap-32 sm:odd:flex-row-reverse">
       <div
-        className="flex flex-col gap-8 text-[1.6rem] font-normal leading-[2.7rem] text-left text-black sm:w-1/2"
+        className="flex flex-col gap-8 text-left text-[1.6rem] font-normal leading-[2.7rem] text-black sm:w-1/2"
         dangerouslySetInnerHTML={createMarkup(text)}
       />
-      <div className="flex relative justify-center items-center w-full sm:w-1/2">
+      <div className="relative flex w-full items-center justify-center sm:w-1/2">
         <Picture
           imageSrc={imageSrc}
           imageAlt={imageAlt}

--- a/apps/consulting/components/JobList/JobList.tsx
+++ b/apps/consulting/components/JobList/JobList.tsx
@@ -16,11 +16,11 @@ export const JobList: FC<TJobListProps> = ({
 
   return (
     <section
-      className="flex flex-col justify-center items-center my-24 mx-auto xl:mt-52 xl:mb-24 max-w-layout"
+      className="max-w-layout mx-auto my-24 flex flex-col items-center justify-center xl:mb-24 xl:mt-52"
       aria-live="polite"
       aria-busy={!error && !data ? 'true' : 'false'}
     >
-      <h2 className="mb-[4.3rem] text-[4rem] font-extrabold leading-[4.9rem] sm:mb-32 sm:text-[4.8rem] text-violet font-heading">
+      <h2 className="text-violet font-heading mb-[4.3rem] text-[4rem] font-extrabold leading-[4.9rem] sm:mb-32 sm:text-[4.8rem]">
         {title}
       </h2>
       {!error && !data && <Loading />}
@@ -28,7 +28,7 @@ export const JobList: FC<TJobListProps> = ({
       {!error && data?.jobs?.length === 0 && (
         <Message message={noOpeningsMessage} />
       )}
-      <ul className="flex flex-col gap-[6rem] px-20 text-center sm:px-0 sm:w-full sm:max-w-[60rem] lg:max-w-[70rem] xl:max-w-[80rem]">
+      <ul className="flex flex-col gap-[6rem] px-20 text-center sm:w-full sm:max-w-[60rem] sm:px-0 lg:max-w-[70rem] xl:max-w-[80rem]">
         {data?.jobs?.map((props) => (
           <JobListItem {...props} key={props.id} />
         ))}

--- a/apps/consulting/components/JobList/JobListItem.tsx
+++ b/apps/consulting/components/JobList/JobListItem.tsx
@@ -7,12 +7,12 @@ export const JobListItem: FC<TJobListItem> = ({
   location,
   title,
 }) => (
-  <li className="sm:flex sm:justify-between sm:items-center">
+  <li className="sm:flex sm:items-center sm:justify-between">
     <a
       target="_blank"
       href={absolute_url}
       rel="noreferrer"
-      className="text-[2rem] font-bold leading-[2.7rem] sm:text-left text-violet"
+      className="text-violet text-[2rem] font-bold leading-[2.7rem] sm:text-left"
     >
       {title}
     </a>

--- a/apps/consulting/components/JobList/StateIndicators/Loading.tsx
+++ b/apps/consulting/components/JobList/StateIndicators/Loading.tsx
@@ -7,12 +7,12 @@ export const Loading: FC = () => (
     </p>
     <div
       aria-hidden="true"
-      className="flex justify-center items-center space-x-2"
+      className="flex items-center justify-center space-x-2"
     >
       {[1, 2, 3].map((item) => (
         <div
           key={item}
-          className="w-8 h-8 rounded-full animate-pulse motion-reduce:animate-none bg-violet"
+          className="bg-violet h-8 w-8 animate-pulse rounded-full motion-reduce:animate-none"
         ></div>
       ))}
     </div>

--- a/apps/consulting/components/JobList/StateIndicators/Message.tsx
+++ b/apps/consulting/components/JobList/StateIndicators/Message.tsx
@@ -7,7 +7,7 @@ type TMessage = {
 export const Message: FC<TMessage> = ({ message }) => (
   <p
     role="alert"
-    className="text-[2rem] font-normal leading-[3rem] text-center text-black sm:text-[3rem]"
+    className="text-center text-[2rem] font-normal leading-[3rem] text-black sm:text-[3rem]"
   >
     {message}
   </p>

--- a/apps/consulting/components/Newsletter/Newsletter.tsx
+++ b/apps/consulting/components/Newsletter/Newsletter.tsx
@@ -41,8 +41,8 @@ export const Newsletter: FC = () => {
   return (
     <section
       className={clsx(
-        'box-border py-[3rem] px-[1rem] my-[3rem] max-w-layout bg-violet',
-        'md:py-[4rem] md:px-[10rem] md:my-[5rem]',
+        'max-w-layout bg-violet my-[3rem] box-border px-[1rem] py-[3rem]',
+        'md:my-[5rem] md:px-[10rem] md:py-[4rem]',
       )}
     >
       <NewsletterHeader text="Subscribe for Updates & News" />
@@ -50,8 +50,8 @@ export const Newsletter: FC = () => {
         <div className="relative md:grow">
           <input
             className={clsx(
-              'p-[1.5rem] w-full text-[1.4rem] text-black',
-              'placeholder:text-[1.4rem] placeholder:text-grey',
+              'w-full p-[1.5rem] text-[1.4rem] text-black',
+              'placeholder:text-grey placeholder:text-[1.4rem]',
               'md:text-[1.6rem] md:placeholder:text-[1.6rem]',
             )}
             type="email"

--- a/apps/consulting/components/Newsletter/NewsletterButton.tsx
+++ b/apps/consulting/components/Newsletter/NewsletterButton.tsx
@@ -10,9 +10,9 @@ export const NewsletterButton: FC<TNewsletterButtonProps> = ({
 }) => (
   <button
     className={clsx(
-      'py-[.7rem] px-[5rem] mt-[1.2rem] w-full text-[1.6rem] leading-[3.9rem] text-white bg-pink',
-      'md:box-border md:mt-0 md:w-[20rem] md:text-[1.8rem]',
-      isSubscribed && 'opacity-50 pointer-events-none',
+      'bg-pink mt-[1.2rem] w-full px-[5rem] py-[.7rem] text-[1.6rem] leading-[3.9rem] text-white',
+      'md:mt-0 md:box-border md:w-[20rem] md:text-[1.8rem]',
+      isSubscribed && 'pointer-events-none opacity-50',
     )}
     title={cta}
     type="submit"

--- a/apps/consulting/components/Newsletter/NewsletterHeader.tsx
+++ b/apps/consulting/components/Newsletter/NewsletterHeader.tsx
@@ -5,7 +5,7 @@ import { TNewsletterHeaderProps } from './types';
 export const NewsletterHeader: FC<TNewsletterHeaderProps> = ({ text }) => (
   <div
     className="
-      mb-[5.2rem] text-[2.2rem] leading-[2.9rem] text-center text-white
+      mb-[5.2rem] text-center text-[2.2rem] leading-[2.9rem] text-white
       md:mb-[3.3rem]
     "
   >

--- a/apps/consulting/components/Newsletter/NewsletterMessage.tsx
+++ b/apps/consulting/components/Newsletter/NewsletterMessage.tsx
@@ -7,7 +7,7 @@ export const NewsletterMessage: FC<TNewsletterMessageProps> = ({ message }) => {
     return (
       <p
         className="
-        absolute top-[-3rem] left-0 w-full text-[1.4rem] text-white
+        absolute left-0 top-[-3rem] w-full text-[1.4rem] text-white
         md:top-[6rem] md:text-center
       "
       >

--- a/apps/consulting/components/Pagination/Pagination.tsx
+++ b/apps/consulting/components/Pagination/Pagination.tsx
@@ -37,7 +37,7 @@ export const Pagination: FC<TPaginationProps> = ({
   };
 
   return (
-    <div className="flex relative justify-center items-center pb-[20rem] mt-[1.1rem] sm:pb-[31.8rem] sm:mt-[4.6rem]">
+    <div className="relative mt-[1.1rem] flex items-center justify-center pb-[20rem] sm:mt-[4.6rem] sm:pb-[31.8rem]">
       {!!shouldRenderPagination && (
         <ReactPaginate
           breakLabel="..."
@@ -63,7 +63,7 @@ export const Pagination: FC<TPaginationProps> = ({
       )}
       <div
         aria-hidden="true"
-        className="absolute right-0 bottom-0 w-[26.832rem] h-[15.7rem] sm:top-0 sm:w-[41.388rem] sm:h-[24.217rem] xl:top-auto xl:right-[-15%] xl:bottom-0"
+        className="absolute bottom-0 right-0 h-[15.7rem] w-[26.832rem] sm:top-0 sm:h-[24.217rem] sm:w-[41.388rem] xl:bottom-0 xl:right-[-15%] xl:top-auto"
       >
         <Picture
           imageSrc={PaginationDecorativeImage}

--- a/apps/consulting/components/Pagination/PaginationIcon.tsx
+++ b/apps/consulting/components/Pagination/PaginationIcon.tsx
@@ -12,7 +12,7 @@ export const PaginationIcon: FC<TPaginationIconProps> = ({ orientation }) => {
   return (
     <div
       className={clsx(
-        'relative  w-[1.5rem] h-[1.5rem]',
+        'relative  h-[1.5rem] w-[1.5rem]',
         orientation === PaginationOrientation.Prev && 'rotate-180',
       )}
     >

--- a/apps/consulting/components/Related/Related.tsx
+++ b/apps/consulting/components/Related/Related.tsx
@@ -6,15 +6,15 @@ import { TRelatedProps } from './types';
 export const Related: FC<TRelatedProps> = ({ title, items }) => (
   <section
     className="
-      py-[7rem] px-[3.5rem] mx-auto lg:px-[13rem] 
-      lg:pt-[11rem] max-w-layout
+      max-w-layout mx-auto px-[3.5rem] py-[7rem] 
+      lg:px-[13rem] lg:pt-[11rem]
     "
   >
     <h2
       className="
-        mb-[5rem] text-[4rem] font-extrabold leading-[4.9rem] text-center lg:mb-[8rem] 
-        lg:text-[4.8rem] font-heading
-        text-violet
+        font-heading text-violet mb-[5rem] text-center text-[4rem] font-extrabold 
+        leading-[4.9rem] lg:mb-[8rem]
+        lg:text-[4.8rem]
       "
     >
       {title}

--- a/apps/consulting/components/Related/RelatedItem.tsx
+++ b/apps/consulting/components/Related/RelatedItem.tsx
@@ -14,7 +14,7 @@ export const RelatedItem: FC<TRelatedItemProps> = ({
 }) => (
   <li className="mb-[3.5rem] shadow-[0_4px_14px_rgba(0,0,0,.11)] md:w-1/3">
     <Link href={linkUrl}>
-      <a className="box-border block px-[6rem] pt-[3rem] pb-[5rem] h-full text-center md:px-0">
+      <a className="box-border block h-full px-[6rem] pb-[5rem] pt-[3rem] text-center md:px-0">
         <Picture
           imageSrc={imageSrc}
           imageAlt={imageAlt}
@@ -23,8 +23,8 @@ export const RelatedItem: FC<TRelatedItemProps> = ({
         />
         <h3
           className="
-            mt-[2.5rem] text-[2.2rem] font-extrabold leading-[3rem] md:mx-auto 
-            md:max-w-[15rem] font-heading
+            font-heading mt-[2.5rem] text-[2.2rem] font-extrabold leading-[3rem] 
+            md:mx-auto md:max-w-[15rem]
           "
         >
           {title}

--- a/apps/consulting/components/StickyNotes/StickyNote/Header.tsx
+++ b/apps/consulting/components/StickyNotes/StickyNote/Header.tsx
@@ -13,7 +13,7 @@ type THeaderProps = {
 export const Header: FC<THeaderProps> = ({ variant, text }) => (
   <h2
     className={clsx(
-      'mb-[3.7rem] text-[4rem] font-extrabold leading-[4.9rem] font-heading',
+      'font-heading mb-[3.7rem] text-[4rem] font-extrabold leading-[4.9rem]',
       'sm:text-[4.8rem]',
       getTextColor(variant),
     )}

--- a/apps/consulting/components/StickyNotes/StickyNote/StickyNote.tsx
+++ b/apps/consulting/components/StickyNotes/StickyNote/StickyNote.tsx
@@ -25,10 +25,10 @@ export const StickyNote: FC<TStickyNoteComponentProps> = ({
 }) => {
   const showButton = buttonLink && buttonText;
   const noteStyle = clsx(
-    'basis-1/2 px-[2.5rem] pb-[3.9rem] h-full sm:px-[5.1rem] sm:pt-[4.1rem] sm:pb-[5.1rem] sm:mx-0',
-    isFirst && 'relative pt-[2.8rem] ml-[2rem] sm:ml-0 z-1',
+    'h-full basis-1/2 px-[2.5rem] pb-[3.9rem] sm:mx-0 sm:px-[5.1rem] sm:pb-[5.1rem] sm:pt-[4.1rem]',
+    isFirst && 'z-1 relative ml-[2rem] pt-[2.8rem] sm:ml-0',
     isLast &&
-      'pt-[11.8rem] mt-[-9rem] mr-[2rem] sm:pt-[4.1rem] sm:mt-0 sm:mr-0',
+      'mr-[2rem] mt-[-9rem] pt-[11.8rem] sm:mr-0 sm:mt-0 sm:pt-[4.1rem]',
     isFirst && getFirstNoteMargins(notesVariant),
     isLast && getLastNoteMargins(notesVariant),
     getBackgroundColor(variant),

--- a/apps/consulting/components/StickyNotes/StickyNotes.tsx
+++ b/apps/consulting/components/StickyNotes/StickyNotes.tsx
@@ -6,7 +6,7 @@ import { TStickyNotesProps, StickyNotesVariant } from './types';
 
 export const StickyNotes: FC<TStickyNotesProps> = ({ variant, items }) => {
   return (
-    <div className="flex relative flex-col items-stretch mx-auto sm:flex-row xl:px-[18rem] max-w-layout">
+    <div className="max-w-layout relative mx-auto flex flex-col items-stretch sm:flex-row xl:px-[18rem]">
       {items.map((item, index, source) => (
         <StickyNote
           key={item.title}

--- a/apps/consulting/components/StickyNotes/StickyNotesDecor.tsx
+++ b/apps/consulting/components/StickyNotes/StickyNotesDecor.tsx
@@ -3,12 +3,12 @@ import { FC } from 'react';
 export const StickyNotesDecor: FC = () => (
   <div
     className="
-      flex absolute right-[3rem] bottom-[-5rem] z-[1] justify-center items-center w-[10rem]
-      h-[10rem] border border-solid rotate-45 sm:right-[2.5rem]
-      sm:bottom-[-3rem] xl:right-[15rem] border-violet
-      sm:border-green
+      border-violet sm:border-green absolute bottom-[-5rem] right-[3rem] z-[1] flex h-[10rem]
+      w-[10rem] rotate-45 items-center justify-center border
+      border-solid sm:bottom-[-3rem] sm:right-[2.5rem]
+      xl:right-[15rem]
     "
   >
-    <div className="w-[73%] h-[73%] rotate-45 bg-violet"></div>
+    <div className="bg-violet h-[73%] w-[73%] rotate-45"></div>
   </div>
 );

--- a/apps/consulting/components/Testimonial/Quote/Avatar.tsx
+++ b/apps/consulting/components/Testimonial/Quote/Avatar.tsx
@@ -7,9 +7,9 @@ import { TAvatarProps } from '../types';
 export const Avatar: FC<TAvatarProps> = ({ imageSrc, imageAlt }) => (
   <div
     className="
-      relative top-[-4rem] w-[8.5rem] h-[8.5rem]
-      md:top-0 md:left-[-6rem] md:w-[15rem] md:h-[15rem]
-      lg:w-[27rem] lg:h-[27rem]
+      relative top-[-4rem] h-[8.5rem] w-[8.5rem]
+      md:left-[-6rem] md:top-0 md:h-[15rem] md:w-[15rem]
+      lg:h-[27rem] lg:w-[27rem]
       xl:left-[-8rem]
     "
   >
@@ -21,9 +21,9 @@ export const Avatar: FC<TAvatarProps> = ({ imageSrc, imageAlt }) => (
     />
     <span
       className="
-        hidden
-        md:block md:absolute md:top-0 md:left-0 md:w-full md:h-full md:opacity-50
-        md:z-2 md:bg-violet
+        md:z-2
+        md:bg-violet hidden md:absolute md:left-0 md:top-0 md:block md:h-full
+        md:w-full md:opacity-50
       "
     />
   </div>

--- a/apps/consulting/components/Testimonial/Quote/Quote.tsx
+++ b/apps/consulting/components/Testimonial/Quote/Quote.tsx
@@ -10,12 +10,12 @@ export const Quote: FC<TQuoteProps> = ({
   person,
   position,
 }) => (
-  <div className="relative mx-auto w-full max-w-[93rem] bg-gray-50 z-1">
-    <div className="relative pb-[5rem] md:flex md:pt-[7rem] md:pb-[6.4rem]">
+  <div className="z-1 relative mx-auto w-full max-w-[93rem] bg-gray-50">
+    <div className="relative pb-[5rem] md:flex md:pb-[6.4rem] md:pt-[7rem]">
       <Avatar imageSrc={imageSrc} imageAlt={imageAlt} />
       <div className="px-[2rem] text-black md:px-0">
         <p className="text-[2rem] leading-[2.7rem]">{testimonial}</p>
-        <p className="pt-[2rem] text-[2.2rem] leading-[3.5rem] font-heading">
+        <p className="font-heading pt-[2rem] text-[2.2rem] leading-[3.5rem]">
           {person}
         </p>
         <p className="text-[1.5rem] leading-[2.7rem]">{position}</p>

--- a/apps/consulting/components/Testimonial/Testimonial.tsx
+++ b/apps/consulting/components/Testimonial/Testimonial.tsx
@@ -14,14 +14,14 @@ export const Testimonial: FC<TTestimonialProps> = ({
   position,
 }) => (
   <section className="md:py-[5rem]">
-    <div className="relative text-white bg-pink">
+    <div className="bg-pink relative text-white">
       <Triangle />
-      <div className="pt-[3.6rem] pb-[14rem] mx-auto md:pt-[11rem] md:pb-[30rem] max-w-layout">
+      <div className="max-w-layout mx-auto pb-[14rem] pt-[3.6rem] md:pb-[30rem] md:pt-[11rem]">
         <div className="px-[2.4rem] md:flex md:gap-[7rem] lg:px-[13rem]">
           <h2
             className="
-              text-[4rem] font-extrabold leading-[4.9rem] md:w-1/2
-              md:text-[4.8rem] font-heading
+              font-heading text-[4rem] font-extrabold leading-[4.9rem]
+              md:w-1/2 md:text-[4.8rem]
             "
           >
             {header}
@@ -32,7 +32,7 @@ export const Testimonial: FC<TTestimonialProps> = ({
         </div>
       </div>
     </div>
-    <div className="px-[2.4rem] mt-[-6.6rem] md:px-[8rem] md:mt-[-20rem]">
+    <div className="mt-[-6.6rem] px-[2.4rem] md:mt-[-20rem] md:px-[8rem]">
       <Quote
         imageSrc={imageSrc}
         imageAlt={imageAlt}

--- a/apps/consulting/components/Testimonial/Triangle.tsx
+++ b/apps/consulting/components/Testimonial/Triangle.tsx
@@ -3,10 +3,10 @@ import { FC } from 'react';
 export const Triangle: FC = () => (
   <span
     className="
-      hidden
-      border-r-[6rem] md:block md:absolute md:-top-1 md:left-1/2 md:w-0 md:h-0
-      md:border-t-[5rem] md:border-l-[6rem] md:border-transparent md:border-t-white
-      md:-translate-x-1/2 md:border-b-none
+      md:border-b-none
+      hidden border-r-[6rem] md:absolute md:-top-1 md:left-1/2 md:block md:h-0
+      md:w-0 md:-translate-x-1/2 md:border-l-[6rem] md:border-t-[5rem]
+      md:border-transparent md:border-t-white
     "
   />
 );

--- a/apps/consulting/components/TextArticle/TextArticle.tsx
+++ b/apps/consulting/components/TextArticle/TextArticle.tsx
@@ -6,22 +6,22 @@ export const TextArticle: FC<TTextArticleProps> = ({ header, text }) => {
   return (
     <article
       className="
-        px-[3.5rem] pt-[5.5rem] pb-[2rem] mx-auto
-        md:grid md:grid-cols-[1fr,1fr] md:py-[8rem]
-        lg:grid-cols-[6fr,7fr] lg:px-[13rem]
-        max-w-layout
+        max-w-layout mx-auto px-[3.5rem] pb-[2rem]
+        pt-[5.5rem] md:grid md:grid-cols-[1fr,1fr]
+        md:py-[8rem] lg:grid-cols-[6fr,7fr]
+        lg:px-[13rem]
       "
     >
       <h2
         className="
-          mb-[2.5rem] text-[4rem] font-extrabold leading-[4.9rem] md:text-[3.8rem]
-          md:leading-[4.8rem] font-heading
-          text-violet
+          font-heading text-violet mb-[2.5rem] text-[4rem] font-extrabold
+          leading-[4.9rem] md:text-[3.8rem]
+          md:leading-[4.8rem]
         "
       >
         {header}
       </h2>
-      <p className="text-[1.6rem] leading-[2.7rem] md:pl-[4rem] md:mt-[1rem]">
+      <p className="text-[1.6rem] leading-[2.7rem] md:mt-[1rem] md:pl-[4rem]">
         {text}
       </p>
     </article>

--- a/apps/consulting/components/Tiles/Tile.tsx
+++ b/apps/consulting/components/Tiles/Tile.tsx
@@ -27,7 +27,7 @@ export const Tile: FC<TTileProps> = ({
       <div
         className={clsx(
           tileVariant === TileVariant.Blog && 'h-[19.8rem] sm:h-[21.9rem]',
-          'relative w-full h-[21.2rem] sm:h-[23rem] lg:h-[16.4rem]',
+          'relative h-[21.2rem] w-full sm:h-[23rem] lg:h-[16.4rem]',
         )}
       >
         <Picture
@@ -43,17 +43,17 @@ export const Tile: FC<TTileProps> = ({
         className={clsx(
           'w-full',
           tileVariant === TileVariant.Blog &&
-            'px-[1.4rem] pt-[0.5rem] pb-[4.4rem] sm:px-[4rem] sm:pt-[1.5rem] sm:pb-[3.3rem]',
+            'px-[1.4rem] pb-[4.4rem] pt-[0.5rem] sm:px-[4rem] sm:pb-[3.3rem] sm:pt-[1.5rem]',
         )}
       >
         {tileVariant === TileVariant.Library && (
-          <p className="pt-8 pb-5 text-[1.4rem] font-normal leading-[3rem] uppercase sm:pb-1 xl:pb-5">
+          <p className="pb-5 pt-8 text-[1.4rem] font-normal uppercase leading-[3rem] sm:pb-1 xl:pb-5">
             {postType}
           </p>
         )}
         <h3
           className={clsx(
-            'w-1/2 text-[2.2rem] font-extrabold leading-[2.9rem] text-black lg:w-full font-heading',
+            'font-heading w-1/2 text-[2.2rem] font-extrabold leading-[2.9rem] text-black lg:w-full',
             tileVariant === TileVariant.Blog && 'leading-[3.7rem]',
           )}
         >
@@ -61,8 +61,8 @@ export const Tile: FC<TTileProps> = ({
         </h3>
         <div
           className={clsx(
-            'flex gap-5 justify-start items-center text-[1.2rem] font-normal leading-[2.7rem] text-black',
-            tileVariant === TileVariant.Blog && 'mt-[0.5rem] ml-[0.4rem]',
+            'flex items-center justify-start gap-5 text-[1.2rem] font-normal leading-[2.7rem] text-black',
+            tileVariant === TileVariant.Blog && 'ml-[0.4rem] mt-[0.5rem]',
           )}
         >
           <p>By {author}</p>

--- a/apps/consulting/components/Tiles/Tiles.tsx
+++ b/apps/consulting/components/Tiles/Tiles.tsx
@@ -21,7 +21,7 @@ export const Tiles: FC<TTilesProps> = ({ tiles, tileVariant }) => {
   return (
     <section>
       {tiles.length === 0 && (
-        <p className="text-[2.2rem] font-extrabold text-center text-black">
+        <p className="text-center text-[2.2rem] font-extrabold text-black">
           We don&apos;t have any posts yet. Please check back later.
         </p>
       )}

--- a/apps/consulting/components/blog-only/BlogCTAButton/BlogCTAButton.tsx
+++ b/apps/consulting/components/blog-only/BlogCTAButton/BlogCTAButton.tsx
@@ -10,7 +10,7 @@ export const BlogCTAButton: FC<TBlogCTAButtonProps> = ({
   return (
     <div className="flex justify-center">
       <button
-        className="py-2 px-8 mt-6 w-fit text-[1.8rem] font-bold leading-[3.7rem] text-white bg-violet"
+        className="bg-violet mt-6 w-fit px-8 py-2 text-[1.8rem] font-bold leading-[3.7rem] text-white"
         onClick={() => {
           window.open(url, target);
         }}

--- a/apps/consulting/components/blog-only/BlogTable/BlogTable.tsx
+++ b/apps/consulting/components/blog-only/BlogTable/BlogTable.tsx
@@ -75,7 +75,7 @@ export const BlogTable: FC<TBlogTableProps> = ({
   );
 
   return (
-    <div className="flex pl-16 md:justify-center md:pl-0 justify-left ">
+    <div className="justify-left flex pl-16 md:justify-center md:pl-0 ">
       <div className={tableDivClassName}>
         <table className="table-fixed">
           <thead>

--- a/apps/consulting/pages/library/index.tsx
+++ b/apps/consulting/pages/library/index.tsx
@@ -132,7 +132,7 @@ export const Library: FC<TLibraryProps> = ({
           {(blok: TRawBlok) => <BlokProvider blok={blok} />}
         </Page>
       )}
-      <div className="px-8 mx-auto lg:px-40 xl:px-[30rem] max-w-layout">
+      <div className="max-w-layout mx-auto px-8 lg:px-40 xl:px-[30rem]">
         {carouselTiles?.length > 0 && (
           <Carousel carouselTiles={carouselTiles} />
         )}

--- a/apps/consulting/pages/nebari-services.tsx
+++ b/apps/consulting/pages/nebari-services.tsx
@@ -75,25 +75,25 @@ export const NebariServicesPage: FC<TContainerProps> = ({
       variant={DomainVariant.Quansight}
     />
 
-    <div className="overflow-hidden w-full h-[100px] bg-[#000]"></div>
+    <div className="h-[100px] w-full overflow-hidden bg-[#000]"></div>
 
-    <div className="relative mx-auto max-w-full h-[52.4rem] sm:h-[calc(780px_-_40vw)] lg:h-[36.7rem] nebari-hero-background">
-      <div className="flex relative flex-col items-center px-[2rem] pt-[13rem] w-full h-full sm:pt-[calc(280px_-_23.4vw)] md:absolute md:px-0 lg:pt-[4rem]">
+    <div className="nebari-hero-background relative mx-auto h-[52.4rem] max-w-full sm:h-[calc(780px_-_40vw)] lg:h-[36.7rem]">
+      <div className="relative flex h-full w-full flex-col items-center px-[2rem] pt-[13rem] sm:pt-[calc(280px_-_23.4vw)] md:absolute md:px-0 lg:pt-[4rem]">
         <Image
           className="mb-[20px] brightness-200"
           alt="Nebari logo"
           src={nebariLogoWhite}
         />
-        <h1 className="px-[5.2rem] mb-[1rem] text-[4.6rem] font-extrabold tracking-wide leading-[1] text-center text-white md:text-[5.6rem] md:leading-[1.2] font-heading">
+        <h1 className="font-heading mb-[1rem] px-[5.2rem] text-center text-[4.6rem] font-extrabold leading-[1] tracking-wide text-white md:text-[5.6rem] md:leading-[1.2]">
           Nebari Services
         </h1>
         <p className="mb-[2em] text-[1.6em] text-white">
           Deployment, support, and training
         </p>
-        <div className="py-[1.2rem] px-[3rem] mb-[6rem] text-center bg-violet">
+        <div className="bg-violet mb-[6rem] px-[3rem] py-[1.2rem] text-center">
           <Link href="/about-us#bookacallform">
             <a
-              className="after:ml-[0.5em] text-[1.7rem] font-bold text-white after:content-[url(/nebari-services/right-pointing-triangle.svg)] font-heading"
+              className="font-heading text-[1.7rem] font-bold text-white after:ml-[0.5em] after:content-[url(/nebari-services/right-pointing-triangle.svg)]"
               onClick={() =>
                 prefillContactFormMessage(
                   "Hi, I'm interested in learning more about your Nebari Services options. Thanks!",
@@ -107,18 +107,18 @@ export const NebariServicesPage: FC<TContainerProps> = ({
       </div>
     </div>
 
-    <section className="flex flex-col flex-nowrap items-center py-24 px-8 mx-auto lg:px-[13rem] max-w-layout">
-      <h2 className="mb-[1em] text-[4.2rem] font-bold tracking-wide leading-[1] text-center md:text-[4.8rem] font-heading">
+    <section className="max-w-layout mx-auto flex flex-col flex-nowrap items-center px-8 py-24 lg:px-[13rem]">
+      <h2 className="font-heading mb-[1em] text-center text-[4.2rem] font-bold leading-[1] tracking-wide md:text-[4.8rem]">
         What is Nebari?
       </h2>
-      <p className="mx-auto mb-[3.7rem] max-w-prose text-[1.6rem] leading-[2.7rem] text-center">
+      <p className="mx-auto mb-[3.7rem] max-w-prose text-center text-[1.6rem] leading-[2.7rem]">
         <span className="font-bold">
           Nebari is on open source data science platform{' '}
         </span>
         for teams with serious computational and collaboration needs, looking
         to:
       </p>
-      <ul className="mb-[4rem] w-[100%] max-w-[900px] list-none md:columns-2 md:gap-[82px] md:mb-[5rem]">
+      <ul className="mb-[4rem] w-[100%] max-w-[900px] list-none md:mb-[5rem] md:columns-2 md:gap-[82px]">
         {[
           'Work in familiar IDEs like JupyterLab or VSCode',
           'Scale work with built-in support for distributed computing with Dask',
@@ -129,14 +129,14 @@ export const NebariServicesPage: FC<TContainerProps> = ({
         ].map((txt) => (
           <li
             key={txt}
-            className="flex before:relative before:top-[6px] before:shrink-0 before:mr-[1em] mb-[1em] before:w-[39px] max-w-prose before:h-[36px] text-[1.6rem] font-bold leading-[2.7rem] before:bg-[url(/nebari-services/quansight-logo.svg)] before:bg-no-repeat before:bg-contain"
+            className="mb-[1em] flex max-w-prose text-[1.6rem] font-bold leading-[2.7rem] before:relative before:top-[6px] before:mr-[1em] before:h-[36px] before:w-[39px] before:shrink-0 before:bg-[url(/nebari-services/quansight-logo.svg)] before:bg-contain before:bg-no-repeat"
           >
             {txt}
           </li>
         ))}
       </ul>
       {/* eslint-disable jsx-a11y/media-has-caption */}
-      <video controls className="px-8 mb-[7rem] w-[100%] max-w-[900px] md:p-0">
+      <video controls className="mb-[7rem] w-[100%] max-w-[900px] px-8 md:p-0">
         <source src="https://a.storyblok.com/f/147759/x/00ddc13b05/nebari-features.mp4" />
         <p>
           A silent video demo of Nebari features using screen recordings and
@@ -144,10 +144,10 @@ export const NebariServicesPage: FC<TContainerProps> = ({
         </p>
       </video>
       {/* eslint-enable jsx-a11y/media-has-caption */}
-      <div className="py-[1.8rem] px-[2.9rem] mb-[1rem] text-center bg-violet">
+      <div className="bg-violet mb-[1rem] px-[2.9rem] py-[1.8rem] text-center">
         <Link href="/about-us#bookacallform">
           <a
-            className="after:ml-[1em] text-[1.7rem] font-bold text-white after:content-[url(/nebari-services/right-pointing-triangle.svg)] font-heading"
+            className="font-heading text-[1.7rem] font-bold text-white after:ml-[1em] after:content-[url(/nebari-services/right-pointing-triangle.svg)]"
             onClick={() =>
               prefillContactFormMessage(
                 'Hi, please send me a login to a demo instance of Nebari so I can check it out. Thanks!',
@@ -158,14 +158,14 @@ export const NebariServicesPage: FC<TContainerProps> = ({
           </a>
         </Link>
       </div>
-      <p className="px-[10rem] max-w-prose font-[400] text-[1.4rem] italic leading-[1.7rem] text-center text-[rgba(0,0,0,1)]">
+      <p className="max-w-prose px-[10rem] text-center text-[1.4rem] font-[400] italic leading-[1.7rem] text-[rgba(0,0,0,1)]">
         Drop us a line and we&rsquo;ll send you a login
       </p>
     </section>
 
     <section className="bg-gray-200">
       <h2 className="sr-only">Used by</h2>
-      <div className="flex flex-col items-center p-20 mx-auto space-y-20 md:overflow-hidden md:flex-row md:justify-evenly md:py-2 md:px-32 md:space-y-0 md:space-x-8 max-w-layout">
+      <div className="max-w-layout mx-auto flex flex-col items-center space-y-20 p-20 md:flex-row md:justify-evenly md:space-x-8 md:space-y-0 md:overflow-hidden md:px-32 md:py-2">
         <Image alt="Morningstar" src={morningstarLogo} className="w-[137px]" />
         <Image
           alt="Earth Science Information Partners"
@@ -181,27 +181,27 @@ export const NebariServicesPage: FC<TContainerProps> = ({
       </div>
     </section>
 
-    <section className="flex flex-col items-center py-24 px-8 mx-auto max-w-layout">
-      <h2 className="mb-[0.9em] text-[4.2rem] font-bold leading-[1] text-center font-heading">
+    <section className="max-w-layout mx-auto flex flex-col items-center px-8 py-24">
+      <h2 className="font-heading mb-[0.9em] text-center text-[4.2rem] font-bold leading-[1]">
         Service Packages
       </h2>
-      <p className="mb-[2em] text-[1.6rem] leading-[1.6] text-center md:max-w-[1016px]">
+      <p className="mb-[2em] text-center text-[1.6rem] leading-[1.6] md:max-w-[1016px]">
         Nebari is designed to be deployed and managed without DevOps expertise.
         However, if you need a helping hand, require special customizations, or
         have complex existing infrastructure, Quansight has some service
         offerings to help you reach your goals.
       </p>
-      <p className="mb-[2em] text-[1.6rem] leading-[1.6] text-center md:max-w-[1016px]">
+      <p className="mb-[2em] text-center text-[1.6rem] leading-[1.6] md:max-w-[1016px]">
         As the creators of Nebari, we know it inside and out, and understand the
         underlying tools, including JupyterHub and Dask. We&apos;re experts in
         data science solutions, and have years of experience deploying and using
         Nebari for various client projects.
       </p>
 
-      <div className="py-[1.7rem] px-[3.5rem] mb-[6rem] text-center bg-pink">
+      <div className="bg-pink mb-[6rem] px-[3.5rem] py-[1.7rem] text-center">
         <Link href="/about-us#bookacallform">
           <a
-            className="after:ml-[0.5em] text-[1.7rem] font-bold text-white after:content-[url(/nebari-services/right-pointing-triangle.svg)] font-heading"
+            className="font-heading text-[1.7rem] font-bold text-white after:ml-[0.5em] after:content-[url(/nebari-services/right-pointing-triangle.svg)]"
             onClick={() =>
               prefillContactFormMessage(
                 "Hi, I'm interested in learning more about your Nebari Services options. Thanks!",
@@ -213,16 +213,16 @@ export const NebariServicesPage: FC<TContainerProps> = ({
         </Link>
       </div>
 
-      <div className="px-[10%] w-full max-w-[405px] md:grid md:grid-cols-3 md:gap-6 md:p-0 md:max-w-[1016px] mx:auto">
+      <div className="mx:auto w-full max-w-[405px] px-[10%] md:grid md:max-w-[1016px] md:grid-cols-3 md:gap-6 md:p-0">
         {/* Starter */}
-        <div className="flex flex-col mb-[5.4rem] min-h-[55rem]">
-          <h3 className="p-8 text-[3rem] font-bold tracking-wide text-center text-white bg-violet font-heading">
+        <div className="mb-[5.4rem] flex min-h-[55rem] flex-col">
+          <h3 className="bg-violet font-heading p-8 text-center text-[3rem] font-bold tracking-wide text-white">
             Starter
           </h3>
-          <p className="grow py-7  px-1 font-[600] text-[1.6rem] italic tracking-wide leading-[2.6rem] text-center bg-gray-200 border-b border-b-black md:grow-0 md:px-2 md:h-[12rem]">
+          <p className="grow border-b  border-b-black bg-gray-200 px-1 py-7 text-center text-[1.6rem] font-[600] italic leading-[2.6rem] tracking-wide md:h-[12rem] md:grow-0 md:px-2">
             Need some assistance with setup
           </p>
-          <ul className="grow-[3] p-8 list-none bg-gray-200">
+          <ul className="grow-[3] list-none bg-gray-200 p-8">
             {[
               'Evaluate needs',
               'Deploy Nebari on your infrastructure',
@@ -231,27 +231,27 @@ export const NebariServicesPage: FC<TContainerProps> = ({
             ].map((txt) => (
               <li
                 key={txt}
-                className="flex before:relative before:top-[6px] before:shrink-0 before:mr-[1em] mb-[8%] before:w-[13px] before:h-[10px] text-[1.6rem] tracking-wide leading-[2.3rem] before:bg-[url(/nebari-services/purple-check-mark.svg)] before:bg-no-repeat before:bg-contain"
+                className="mb-[8%] flex text-[1.6rem] leading-[2.3rem] tracking-wide before:relative before:top-[6px] before:mr-[1em] before:h-[10px] before:w-[13px] before:shrink-0 before:bg-[url(/nebari-services/purple-check-mark.svg)] before:bg-contain before:bg-no-repeat"
               >
                 {txt}
               </li>
             ))}
           </ul>
-          <div className="p-7 text-[4rem] font-bold tracking-wide text-center text-white bg-pink font-heading">
+          <div className="bg-pink font-heading p-7 text-center text-[4rem] font-bold tracking-wide text-white">
             $5k
           </div>
         </div>
 
         {/* Standard */}
-        <div className="flex flex-col mb-[5.4rem] min-h-[55rem]">
-          <h3 className="p-8 text-[3rem] font-bold tracking-wide text-center text-white bg-violet font-heading">
+        <div className="mb-[5.4rem] flex min-h-[55rem] flex-col">
+          <h3 className="bg-violet font-heading p-8 text-center text-[3rem] font-bold tracking-wide text-white">
             Standard
           </h3>
-          <p className="grow py-7 px-1 font-[600] text-[1.6rem] italic tracking-wide leading-[2.6rem] text-center bg-gray-200 border-b border-b-black md:grow-0 md:px-2 md:h-[12rem]">
+          <p className="grow border-b border-b-black bg-gray-200 px-1 py-7 text-center text-[1.6rem] font-[600] italic leading-[2.6rem] tracking-wide md:h-[12rem] md:grow-0 md:px-2">
             Need assistance with setup, onboarding users, and migrating
             workflows
           </p>
-          <ul className="grow-[3] p-8 list-none bg-gray-200 md:grow">
+          <ul className="grow-[3] list-none bg-gray-200 p-8 md:grow">
             {[
               'All Starter-tier services',
               'User training (up to 15 people)',
@@ -261,27 +261,27 @@ export const NebariServicesPage: FC<TContainerProps> = ({
             ].map((txt) => (
               <li
                 key={txt}
-                className="flex before:relative before:top-[6px] before:shrink-0 before:mr-[1em] mb-[8%] before:w-[13px] before:h-[10px] text-[1.6rem] tracking-wide leading-[2.3rem] before:bg-[url(/nebari-services/purple-check-mark.svg)] before:bg-no-repeat before:bg-contain"
+                className="mb-[8%] flex text-[1.6rem] leading-[2.3rem] tracking-wide before:relative before:top-[6px] before:mr-[1em] before:h-[10px] before:w-[13px] before:shrink-0 before:bg-[url(/nebari-services/purple-check-mark.svg)] before:bg-contain before:bg-no-repeat"
               >
                 {txt}
               </li>
             ))}
           </ul>
-          <div className="p-7 text-[4rem] font-bold tracking-wide text-center text-white bg-pink font-heading">
+          <div className="bg-pink font-heading p-7 text-center text-[4rem] font-bold tracking-wide text-white">
             $20k
           </div>
         </div>
 
         {/* Plus */}
-        <div className="flex flex-col mb-[5.4rem] min-h-[55rem]">
-          <h3 className="p-8 text-[3rem] font-bold tracking-wide text-center text-white bg-violet font-heading">
+        <div className="mb-[5.4rem] flex min-h-[55rem] flex-col">
+          <h3 className="bg-violet font-heading p-8 text-center text-[3rem] font-bold tracking-wide text-white">
             Plus
           </h3>
-          <p className="grow py-7 px-1 font-[600] text-[1.6rem] italic tracking-wide leading-[2.6rem] text-center bg-gray-200 border-b border-b-black md:flex md:grow-0 md:items-center md:px-2 md:h-[12rem]">
+          <p className="grow border-b border-b-black bg-gray-200 px-1 py-7 text-center text-[1.6rem] font-[600] italic leading-[2.6rem] tracking-wide md:flex md:h-[12rem] md:grow-0 md:items-center md:px-2">
             Need assistance with setup, onboarding users, migrating workflows,
             and custom integrations
           </p>
-          <ul className="grow-[3] p-8 list-none bg-gray-200 md:flex md:flex-col">
+          <ul className="grow-[3] list-none bg-gray-200 p-8 md:flex md:flex-col">
             {[
               'All Standard-tier services',
               'User training (up to 45 people)',
@@ -292,50 +292,50 @@ export const NebariServicesPage: FC<TContainerProps> = ({
             ].map((txt) => (
               <li
                 key={txt}
-                className="flex before:relative before:top-[6px] shrink before:shrink-0 before:mr-[1em] mb-[8%] before:w-[13px] before:h-[10px] text-[1.6rem] tracking-wide leading-[2.3rem] before:bg-[url(/nebari-services/purple-check-mark.svg)] before:bg-no-repeat before:bg-contain"
+                className="mb-[8%] flex shrink text-[1.6rem] leading-[2.3rem] tracking-wide before:relative before:top-[6px] before:mr-[1em] before:h-[10px] before:w-[13px] before:shrink-0 before:bg-[url(/nebari-services/purple-check-mark.svg)] before:bg-contain before:bg-no-repeat"
               >
                 {txt}
               </li>
             ))}
           </ul>
-          <div className="p-7 text-[4rem] font-bold tracking-wide text-center text-white bg-pink font-heading">
+          <div className="bg-pink font-heading p-7 text-center text-[4rem] font-bold tracking-wide text-white">
             $50k
           </div>
         </div>
       </div>
 
-      <div className="px-[10%] mb-[3.4em] w-full max-w-[405px] md:grid md:grid-cols-2 md:gap-10 md:p-0 md:max-w-[1016px]">
-        <div className="flex flex-col mb-[3.4rem]">
-          <h3 className="p-8 text-[3rem] font-bold tracking-wide text-center text-white bg-violet font-heading">
+      <div className="mb-[3.4em] w-full max-w-[405px] px-[10%] md:grid md:max-w-[1016px] md:grid-cols-2 md:gap-10 md:p-0">
+        <div className="mb-[3.4rem] flex flex-col">
+          <h3 className="bg-violet font-heading p-8 text-center text-[3rem] font-bold tracking-wide text-white">
             Fully managed
           </h3>
-          <p className="grow py-10 px-4 font-[500] text-[1.6rem] tracking-wide leading-[2.6rem] text-center bg-gray-200">
+          <p className="grow bg-gray-200 px-4 py-10 text-center text-[1.6rem] font-[500] leading-[2.6rem] tracking-wide">
             Nebari deployment on your infrastructure, completely managed and
             maintained by Quansight, with dedicated user support.
           </p>
         </div>
 
-        <div className="flex flex-col mb-[3.4rem]">
-          <h3 className="p-8 text-[3rem] font-bold tracking-wide text-center text-white bg-violet font-heading">
+        <div className="mb-[3.4rem] flex flex-col">
+          <h3 className="bg-violet font-heading p-8 text-center text-[3rem] font-bold tracking-wide text-white">
             Event services
           </h3>
-          <p className="grow py-10 px-4 font-[500] text-[1.6rem] tracking-wide leading-[2.6rem] text-center bg-gray-200">
+          <p className="grow bg-gray-200 px-4 py-10 text-center text-[1.6rem] font-[500] leading-[2.6rem] tracking-wide">
             One-time Nebari deployment and management to run tutorials and
             workshops, with user and infrastructure support during the event.{' '}
           </p>
         </div>
       </div>
 
-      <h3 className="mb-[1em] text-[3rem] font-bold tracking-wide leading-[4.3rem] text-center font-heading">
+      <h3 className="font-heading mb-[1em] text-center text-[3rem] font-bold leading-[4.3rem] tracking-wide">
         Interested in Nebari services,
         <br />
         or a more customized solution?
       </h3>
 
-      <div className="py-[1.7rem] px-[3.5rem] mb-[1.9rem] text-center bg-pink">
+      <div className="bg-pink mb-[1.9rem] px-[3.5rem] py-[1.7rem] text-center">
         <Link href="/about-us#bookacallform">
           <a
-            className="after:ml-[0.5em] text-[1.7rem] font-bold text-white after:content-[url(/nebari-services/right-pointing-triangle.svg)] font-heading"
+            className="font-heading text-[1.7rem] font-bold text-white after:ml-[0.5em] after:content-[url(/nebari-services/right-pointing-triangle.svg)]"
             onClick={() =>
               prefillContactFormMessage(
                 "Hi, I'm interested in learning more about your Nebari Services options. Thanks!",
@@ -347,12 +347,7 @@ export const NebariServicesPage: FC<TContainerProps> = ({
         </Link>
       </div>
 
-      <ul
-        className="flex flex-col grow-[3] p-8"
-        style={{
-          listStyleImage: 'url(/nebari-services/purple-check-mark.svg)',
-        }}
-      >
+      <ul className="flex grow-[3] list-image-[url(/nebari-services/purple-check-mark.svg)] flex-col p-8">
         {[
           'A guided, hands-on Nebari demo',
           'Custom integrations',
@@ -361,7 +356,7 @@ export const NebariServicesPage: FC<TContainerProps> = ({
         ].map((txt) => (
           <li
             key={txt}
-            className="mb-[0.4em] font-[700] text-[1.9rem] tracking-wide"
+            className="mb-[0.4em] text-[1.9rem] font-[700] tracking-wide"
           >
             {txt}
           </li>
@@ -372,7 +367,7 @@ export const NebariServicesPage: FC<TContainerProps> = ({
     <section className="bg-violet">
       <h2 className="sr-only">Testimonials</h2>
       <div
-        className="p-4 mx-auto sm:px-[3.4rem] xl:px-[11.5rem] max-w-layout"
+        className="max-w-layout mx-auto p-4 sm:px-[3.4rem] xl:px-[11.5rem]"
         style={{
           background:
             'url(/nebari-services/quansight-logo-violet-grayscale.svg) right bottom / 325px no-repeat',
@@ -398,8 +393,8 @@ export const NebariServicesPage: FC<TContainerProps> = ({
           navigation={true}
         >
           <SwiperSlide>
-            <figure className="py-10 px-24 text-white">
-              <blockquote className="before:relative before:top-[45px] before:left-[-30px] text-[1.8rem] before:text-[10rem] italic font-semibold leading-[2.7rem] before:text-white before:content-['“']">
+            <figure className="px-24 py-10 text-white">
+              <blockquote className="text-[1.8rem] font-semibold italic leading-[2.7rem] before:relative before:left-[-30px] before:top-[45px] before:text-[10rem] before:text-white before:content-['“']">
                 <p className="mb-[1em]">
                   It [Nebari] is a really good way to produce a scalable Jupyter
                   data science platform on whichever cloud you need. The Nebari
@@ -416,8 +411,8 @@ export const NebariServicesPage: FC<TContainerProps> = ({
             </figure>
           </SwiperSlide>
           <SwiperSlide>
-            <figure className="py-10 px-24 text-white">
-              <blockquote className="before:relative before:top-[45px] before:left-[-30px] text-[1.8rem] before:text-[10rem] italic font-semibold leading-[2.7rem] before:text-white before:content-['“']">
+            <figure className="px-24 py-10 text-white">
+              <blockquote className="text-[1.8rem] font-semibold italic leading-[2.7rem] before:relative before:left-[-30px] before:top-[45px] before:text-[10rem] before:text-white before:content-['“']">
                 <p className="mb-[1em]">
                   We engaged Quansight with some Jupyter [custom on-prem
                   Nebari], Python team development, data visualization skills in
@@ -433,8 +428,8 @@ export const NebariServicesPage: FC<TContainerProps> = ({
             </figure>
           </SwiperSlide>
           <SwiperSlide>
-            <figure className="py-10 px-24 text-white">
-              <blockquote className="before:relative before:top-[45px] before:left-[-30px] text-[1.8rem] before:text-[10rem] italic font-semibold leading-[2.7rem] before:text-white before:content-['“']">
+            <figure className="px-24 py-10 text-white">
+              <blockquote className="text-[1.8rem] font-semibold italic leading-[2.7rem] before:relative before:left-[-30px] before:top-[45px] before:text-[10rem] before:text-white before:content-['“']">
                 <p className="mb-[1em]">
                   Before Nebari, we needed a devops engineer to launch and
                   maintain the deployment for ESIP, but now anyone can maintain
@@ -457,8 +452,8 @@ export const NebariServicesPage: FC<TContainerProps> = ({
             </figure>
           </SwiperSlide>
           <SwiperSlide>
-            <figure className="py-10 px-24 text-white">
-              <blockquote className="before:relative before:top-[45px] before:left-[-30px] text-[1.8rem] before:text-[10rem] italic font-semibold leading-[2.7rem] before:text-white before:content-['“']">
+            <figure className="px-24 py-10 text-white">
+              <blockquote className="text-[1.8rem] font-semibold italic leading-[2.7rem] before:relative before:left-[-30px] before:top-[45px] before:text-[10rem] before:text-white before:content-['“']">
                 <p className="mb-[1em]">
                   Nebari is not only easy to deploy and maintain, but our users
                   have found conda-store to be critical for effectively working
@@ -475,8 +470,8 @@ export const NebariServicesPage: FC<TContainerProps> = ({
             </figure>
           </SwiperSlide>
           <SwiperSlide>
-            <figure className="py-10 px-24 text-white">
-              <blockquote className="before:relative before:top-[45px] before:left-[-30px] text-[1.8rem] before:text-[10rem] italic font-semibold leading-[2.7rem] before:text-white before:content-['“']">
+            <figure className="px-24 py-10 text-white">
+              <blockquote className="text-[1.8rem] font-semibold italic leading-[2.7rem] before:relative before:left-[-30px] before:top-[45px] before:text-[10rem] before:text-white before:content-['“']">
                 <p className="mb-[1em]">
                   We chose Nebari to help manage our Kubernetes services better.
                   With no full-time DevOps person, we needed a solution that
@@ -496,8 +491,8 @@ export const NebariServicesPage: FC<TContainerProps> = ({
       </div>
     </section>
 
-    <section className="flex flex-col items-center py-28 px-12 mx-auto max-w-layout">
-      <h2 className="mb-[1em] text-[4.2rem] leading-[1.16] text-center font-heading">
+    <section className="max-w-layout mx-auto flex flex-col items-center px-12 py-28">
+      <h2 className="font-heading mb-[1em] text-center text-[4.2rem] leading-[1.16]">
         Frequently Asked Questions
       </h2>
       <div className="w-full text-[1.6rem] font-normal leading-[1.3] sm:px-[3.4rem] xl:px-[11.5rem]">
@@ -732,20 +727,20 @@ export const NebariServicesPage: FC<TContainerProps> = ({
         ].map(([question, answer]) => (
           <details
             key={String(question)}
-            className="py-12 px-4 space-y-8 border-b border-b-gray-300"
+            className="space-y-8 border-b border-b-gray-300 px-4 py-12"
           >
-            <summary className="text-[2.8rem] font-bold leading-[1.1] font-heading">
+            <summary className="font-heading text-[2.8rem] font-bold leading-[1.1]">
               {question}
             </summary>
-            <div className="space-y-8 max-w-prose">{answer}</div>
+            <div className="max-w-prose space-y-8">{answer}</div>
           </details>
         ))}
       </div>
 
-      <div className="py-[1.7rem] px-[3.5rem] mt-[6rem] text-center bg-violet">
+      <div className="bg-violet mt-[6rem] px-[3.5rem] py-[1.7rem] text-center">
         <Link href="/about-us#bookacallform">
           <a
-            className="after:ml-[0.5em] text-[1.7rem] font-bold text-white after:content-[url(/nebari-services/right-pointing-triangle.svg)] font-heading"
+            className="font-heading text-[1.7rem] font-bold text-white after:ml-[0.5em] after:content-[url(/nebari-services/right-pointing-triangle.svg)]"
             onClick={() =>
               prefillContactFormMessage(
                 "Hi, I'm interested in learning more about your Nebari Services options. Thanks!",
@@ -758,15 +753,15 @@ export const NebariServicesPage: FC<TContainerProps> = ({
       </div>
     </section>
 
-    <section className="flex flex-col items-center py-36 px-12 bg-black md:bg-white">
-      <div className="mb-[1em] max-w-[70rem] text-[3rem] font-bold tracking-wide leading-[1.43] text-center text-white md:text-black font-heading">
+    <section className="flex flex-col items-center bg-black px-12 py-36 md:bg-white">
+      <div className="font-heading mb-[1em] max-w-[70rem] text-center text-[3rem] font-bold leading-[1.43] tracking-wide text-white md:text-black">
         <h2 className="inline">Learn more</h2> about Nebari deployment,
         training, and support.
       </div>
-      <div className="py-[1.8rem] px-[2.9rem] mb-[1rem] text-center bg-pink">
+      <div className="bg-pink mb-[1rem] px-[2.9rem] py-[1.8rem] text-center">
         <a
           href="https://a.storyblok.com/f/147759/x/9c608eb5e1/quansight-more-about-nebari-services.pdf"
-          className="after:ml-[1em] text-[1.7rem] font-bold text-white after:content-[url(/nebari-services/right-pointing-triangle.svg)] font-heading"
+          className="font-heading text-[1.7rem] font-bold text-white after:ml-[1em] after:content-[url(/nebari-services/right-pointing-triangle.svg)]"
         >
           Download the PDF
         </a>

--- a/apps/consulting/pages/opt-out-analytics.tsx
+++ b/apps/consulting/pages/opt-out-analytics.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { OptOutAnalytics } from '@quansight/shared/ui-components';
 
 export const OptOutAnalyticsPage = () => (
-  <div className="mx-auto text-[2em] prose">
+  <div className="prose mx-auto text-[2em]">
     <OptOutAnalytics domain="quansight.com" />
     <hr />
     <p>

--- a/apps/consulting/pages/post/[slug].tsx
+++ b/apps/consulting/pages/post/[slug].tsx
@@ -56,13 +56,13 @@ const Article: FC<TLibraryArticleProps> = ({
           objectFit="cover"
         />
       )}
-      <article className="px-[2rem] mx-auto sm:px-[6rem] lg:px-[10rem] xl:px-[25rem] max-w-layout">
+      <article className="max-w-layout mx-auto px-[2rem] sm:px-[6rem] lg:px-[10rem] xl:px-[25rem]">
         <BlogHeader
           postTitle={post.meta.title}
           publishedDate={post.meta.published}
           author={post.meta.author}
         />
-        <div className="prose-code:px-0 prose-pre:px-0 prose-img:mx-auto prose-figcaption:mt-[2rem] mb-[5rem] min-w-full prose-code:text-[.95em] text-[1.8rem]  prose-code:font-normal leading-[2.7rem] text-black prose-a:underline-offset-2 prose-code:before:content-none prose-code:after:content-none prose-code:bg-transparent prose-pre:bg-transparent prose-code:rounded-lg prose-code:border-none prose sm:prose-figcaption:mt-0 focus:prose-a:text-violet hover:prose-a:text-violet prose-code:text-violet-code prose-code:font-code">
+        <div className="prose-code:px-0 prose-pre:px-0 prose-img:mx-auto prose-figcaption:mt-[2rem] prose-code:text-[.95em] prose-code:font-normal prose-a:underline-offset-2 prose-code:before:content-none  prose-code:after:content-none prose-code:bg-transparent prose-pre:bg-transparent prose-code:rounded-lg prose-code:border-none prose sm:prose-figcaption:mt-0 focus:prose-a:text-violet hover:prose-a:text-violet prose-code:text-violet-code prose-code:font-code mb-[5rem] min-w-full text-[1.8rem] leading-[2.7rem] text-black">
           <MDXRemote {...post.content} components={blogAllowedComponents} />
         </div>
       </article>

--- a/apps/labs/components/PageHeading/PageHeading.tsx
+++ b/apps/labs/components/PageHeading/PageHeading.tsx
@@ -3,8 +3,8 @@ import { FC } from 'react';
 import { TPageHeadingProps } from './types';
 
 export const PageHeading: FC<TPageHeadingProps> = ({ title, description }) => (
-  <section className="px-[3.5rem] pt-[6rem] pb-[3.2rem] mx-auto sm:pt-[8rem] sm:pb-[10rem] sm:text-center xl:pt-[5.5rem] xl:pb-[9rem] max-w-layout">
-    <h1 className="text-[4rem] font-extrabold leading-[4.9rem] sm:mb-[2rem] sm:text-[4.8rem] text-violet font-heading">
+  <section className="max-w-layout mx-auto px-[3.5rem] pb-[3.2rem] pt-[6rem] sm:pb-[10rem] sm:pt-[8rem] sm:text-center xl:pb-[9rem] xl:pt-[5.5rem]">
+    <h1 className="text-violet font-heading text-[4rem] font-extrabold leading-[4.9rem] sm:mb-[2rem] sm:text-[4.8rem]">
       {title}
     </h1>
     <p className="text-[1.6rem] font-normal leading-[2.7rem]">{description}</p>

--- a/apps/labs/components/Post/FeaturedPosts/FeaturedPosts.tsx
+++ b/apps/labs/components/Post/FeaturedPosts/FeaturedPosts.tsx
@@ -12,19 +12,19 @@ export type TFeaturedPostsProps = {
 
 export const FeaturedPosts: FC<TFeaturedPostsProps> = ({ posts }) => {
   return (
-    <div className="pt-[9.9rem] pb-[11.4rem]">
-      <h3 className="mb-[5rem] text-[1.9rem] font-bold leading-[2.7rem] text-center text-black">
+    <div className="pb-[11.4rem] pt-[9.9rem]">
+      <h3 className="mb-[5rem] text-center text-[1.9rem] font-bold leading-[2.7rem] text-black">
         More articles from our Blog
       </h3>
 
       <div className="flex flex-col justify-start sm:flex-row">
         {posts.map((post) => (
           <div
-            className="first:mb-[3.6rem] w-full border border-gray-300 border-solid sm:first:mr-[2.2rem] sm:first:mb-0 sm:w-1/2"
+            className="w-full border border-solid border-gray-300 first:mb-[3.6rem] sm:w-1/2 sm:first:mb-0 sm:first:mr-[2.2rem]"
             key={post.slug}
           >
             {post.meta.featuredImage && (
-              <div className="relative w-full h-[20rem]">
+              <div className="relative h-[20rem] w-full">
                 <Picture
                   layout="fill"
                   objectFit="cover"
@@ -33,7 +33,7 @@ export const FeaturedPosts: FC<TFeaturedPostsProps> = ({ posts }) => {
                 />
               </div>
             )}
-            <div className="px-[1.5rem] pt-[1.5rem] pb-[3rem]">
+            <div className="px-[1.5rem] pb-[3rem] pt-[1.5rem]">
               <h4 className="text-[2.2rem] font-extrabold leading-[3.7rem] text-black">
                 <Link href={`/blog/${post.slug}`}>
                   <a>{post.meta.title}</a>

--- a/apps/labs/components/Post/PostMetaSection/PostAuthor/PostAuthor.tsx
+++ b/apps/labs/components/Post/PostMetaSection/PostAuthor/PostAuthor.tsx
@@ -12,7 +12,7 @@ export const PostAuthor: FC<TPostAuthorProps> = ({
   avatarSrc,
 }) => (
   <div className="flex">
-    <div className="overflow-hidden mr-[0.8rem] w-[48px] h-[48px] rounded-[50%]">
+    <div className="mr-[0.8rem] h-[48px] w-[48px] overflow-hidden rounded-[50%]">
       <Picture
         width={48}
         height={48}
@@ -22,10 +22,10 @@ export const PostAuthor: FC<TPostAuthorProps> = ({
       />
     </div>
     <div>
-      <p className="text-[1.4rem] font-normal leading-[2.7rem] text-black text-sans">
+      <p className="text-sans text-[1.4rem] font-normal leading-[2.7rem] text-black">
         {nickName}
       </p>
-      <p className="text-[1.9rem] font-bold leading-[2.7rem] text-black text-sans">
+      <p className="text-sans text-[1.9rem] font-bold leading-[2.7rem] text-black">
         {fullName}
       </p>
     </div>

--- a/apps/labs/components/Post/PostMetaSection/PostMetaSection.tsx
+++ b/apps/labs/components/Post/PostMetaSection/PostMetaSection.tsx
@@ -15,10 +15,10 @@ export const PostMetaSection: FC<PostMetaSectionProps> = ({
 }) => {
   return (
     <>
-      <h2 className="mb-[5rem] text-[4.8rem] font-extrabold leading-[5.3rem] font-heading text-violet">
+      <h2 className="font-heading text-violet mb-[5rem] text-[4.8rem] font-extrabold leading-[5.3rem]">
         {title}
       </h2>
-      <p className="pb-[3rem] text-[1.4rem] leading-[2.7rem] text-black text-sans">
+      <p className="text-sans pb-[3rem] text-[1.4rem] leading-[2.7rem] text-black">
         Published {published}
       </p>
       <div className="mb-[5rem]">

--- a/apps/labs/components/Posts/CategoryList/CategoryList.tsx
+++ b/apps/labs/components/Posts/CategoryList/CategoryList.tsx
@@ -24,7 +24,7 @@ export const CategoryList: FC<TCategoryListProps> = ({
           onClick(categoryName);
         }}
         className={clsx(
-          'py-[0.7rem] px-[0.8rem] last:mr-0 text-[1.1rem] !font-normal !leading-[2.7rem] text-white whitespace-nowrap',
+          'whitespace-nowrap px-[0.8rem] py-[0.7rem] text-[1.1rem] !font-normal !leading-[2.7rem] text-white last:mr-0',
           {
             '!text-black !bg-white': selectedCategory !== categoryName,
           },

--- a/apps/labs/components/Posts/PostListItem/PostListItem.tsx
+++ b/apps/labs/components/Posts/PostListItem/PostListItem.tsx
@@ -14,13 +14,13 @@ export type TPostListItem = {
 
 export const PostListItem: FC<TPostListItem> = ({ post, variant }) => (
   <div
-    className={clsx('flex flex-row border border-gray-300 border-solid', {
+    className={clsx('flex flex-row border border-solid border-gray-300', {
       'flex-col': variant === 'vertical',
     })}
   >
     {post.meta.featuredImage && (
       <div
-        className={clsx('relative mb-[1.1rem] w-full h-[20rem]', {
+        className={clsx('relative mb-[1.1rem] h-[20rem] w-full', {
           'mb-0 w-1/2': variant === 'horizontal',
         })}
       >
@@ -39,7 +39,7 @@ export const PostListItem: FC<TPostListItem> = ({ post, variant }) => (
     >
       <h3
         className={clsx(
-          'text-[2.4rem] font-extrabold leading-[3rem] text-heading text-violet',
+          'text-heading text-violet text-[2.4rem] font-extrabold leading-[3rem]',
           {
             'my-[2rem]': variant === 'horizontal',
           },
@@ -49,7 +49,7 @@ export const PostListItem: FC<TPostListItem> = ({ post, variant }) => (
           <a>{post.meta.title}</a>
         </Link>
       </h3>
-      <p className="text-[1.2rem] font-normal leading-[2.7rem] text-black text-sans">
+      <p className="text-sans text-[1.2rem] font-normal leading-[2.7rem] text-black">
         By {post.meta.author.fullName} {post.meta.published}
       </p>
     </div>

--- a/apps/labs/components/Projects/ProjectDescription.tsx
+++ b/apps/labs/components/Projects/ProjectDescription.tsx
@@ -9,11 +9,11 @@ export const ProjectDescription = ({
   linkUrl,
   linkText,
 }: TProjectDescriptionProps) => (
-  <div className="pb-[2.8rem] border-b border-b-gray-500 sm:col-start-1 sm:col-end-2 ">
+  <div className="border-b border-b-gray-500 pb-[2.8rem] sm:col-start-1 sm:col-end-2 ">
     {isDroprownExpanded && (
       <div className="w-full">
         <div
-          className="mb-[4rem] prose-p:leading-[2.1rem] text-black prose"
+          className="prose-p:leading-[2.1rem] prose mb-[4rem] text-black"
           dangerouslySetInnerHTML={createMarkup(longDescription)}
         />
         <a
@@ -21,7 +21,7 @@ export const ProjectDescription = ({
           href={linkUrl}
           target="_blank"
           rel="noreferrer"
-          className="text-[1.6rem] font-bold leading-[1.8rem] border-b-2 text-violet border-b-violet"
+          className="text-violet border-b-violet border-b-2 text-[1.6rem] font-bold leading-[1.8rem]"
         >
           {linkText}
         </a>

--- a/apps/labs/components/Projects/ProjectHeadline.tsx
+++ b/apps/labs/components/Projects/ProjectHeadline.tsx
@@ -7,25 +7,25 @@ export const ProjectHeadline = ({
   toggleItemDropdown,
   title,
 }: TProjectHeadlineProps) => (
-  <div className="flex relative justify-between items-center w-full sm:col-start-1 sm:col-end-2">
+  <div className="relative flex w-full items-center justify-between sm:col-start-1 sm:col-end-2">
     <h2
       id={title}
-      className="shrink-0 text-[4rem] font-extrabold leading-[6.648rem] font-heading text-violet"
+      className="font-heading text-violet shrink-0 text-[4rem] font-extrabold leading-[6.648rem]"
     >
       {title}
     </h2>
     <button
       onClick={toggleItemDropdown}
-      className="flex absolute flex-row-reverse items-center w-[100%] h-[6rem]"
+      className="absolute flex h-[6rem] w-[100%] flex-row-reverse items-center"
       aria-expanded={isDroprownExpanded}
     >
       <span className="sr-only">Read more of {title}</span>
       <span
         className={clsx(
-          'border-x-8 border-t-8 border-x-transparent transition-all motion-reduce:transition-none duration-300 ease-in-out border-y-solid border-l-solid',
+          'border-y-solid border-l-solid border-x-8 border-t-8 border-x-transparent transition-all duration-300 ease-in-out motion-reduce:transition-none',
           isDroprownExpanded
-            ? '-rotate-180 border-t-violet'
-            : 'rotate-0 border-t-gray',
+            ? 'border-t-violet -rotate-180'
+            : 'border-t-gray rotate-0',
         )}
       />
     </button>

--- a/apps/labs/components/Projects/ProjectLogo.tsx
+++ b/apps/labs/components/Projects/ProjectLogo.tsx
@@ -9,13 +9,13 @@ export const ProjectLogo = ({
   imageSrc,
   imageAlt,
 }: TProjectLogoProps) => (
-  <div className="sm:col-start-2 sm:col-end-3 sm:row-start-1 sm:row-end-4 sm:pt-[3rem] sm:ml-[6rem] sm:w-[20rem] lg:w-[30rem] xl:w-[35rem]">
+  <div className="sm:col-start-2 sm:col-end-3 sm:row-start-1 sm:row-end-4 sm:ml-[6rem] sm:w-[20rem] sm:pt-[3rem] lg:w-[30rem] xl:w-[35rem]">
     {isDroprownExpanded && (
       <div className="w-full">
         {imageSrc && imageAlt && (
           <div
             className={clsx(
-              'relative w-full h-[11.3rem] lg:h-[13.5rem] ',
+              'relative h-[11.3rem] w-full lg:h-[13.5rem] ',
               isDroprownExpanded ? 'sm:block' : 'sm:hidden',
             )}
           >

--- a/apps/labs/components/Projects/ProjectSummary.tsx
+++ b/apps/labs/components/Projects/ProjectSummary.tsx
@@ -4,7 +4,7 @@ import { TProjectSummaryProps } from './types';
 
 export const ProjectSummary = ({ shortDescription }: TProjectSummaryProps) => (
   <div
-    className="my-[1.8rem] prose-p:leading-[2.1rem] text-black prose sm:col-start-1 sm:col-end-2"
+    className="prose-p:leading-[2.1rem] prose my-[1.8rem] text-black sm:col-start-1 sm:col-end-2"
     dangerouslySetInnerHTML={createMarkup(shortDescription)}
   />
 );

--- a/apps/labs/components/Projects/Projects.tsx
+++ b/apps/labs/components/Projects/Projects.tsx
@@ -6,7 +6,7 @@ import { TProjectsProps } from './types';
 export const Projects: FC<TProjectsProps> = ({ projects }) => (
   <section
     title="List of our projects"
-    className="flex flex-col gap-[6rem] px-[3.5rem] pb-[10rem] mx-auto sm:gap-[3.1rem] sm:px-[5.7rem] lg:gap-[2.6rem] lg:px-[11.7rem] xl:px-[14.1rem] xl:pb-[14rem] max-w-layout"
+    className="max-w-layout mx-auto flex flex-col gap-[6rem] px-[3.5rem] pb-[10rem] sm:gap-[3.1rem] sm:px-[5.7rem] lg:gap-[2.6rem] lg:px-[11.7rem] xl:px-[14.1rem] xl:pb-[14rem]"
   >
     {projects.map((project) => (
       <ProjectsItem key={project._uid} {...project} />

--- a/apps/labs/pages/blog/[slug].tsx
+++ b/apps/labs/pages/blog/[slug].tsx
@@ -71,7 +71,7 @@ export const BlogPost: FC<TBlogPostProps> = ({
       )}
       <article
         className={clsx(
-          'pt-[7.5rem] pb-[11.4rem] mx-auto w-[95%] max-w-[100.17rem] border-gray-100 border-solid md:w-[85%] xl:w-[70%]',
+          'mx-auto w-[95%] max-w-[100.17rem] border-solid border-gray-100 pb-[11.4rem] pt-[7.5rem] md:w-[85%] xl:w-[70%]',
           {
             'border-b': featuredPosts.length,
           },
@@ -81,7 +81,7 @@ export const BlogPost: FC<TBlogPostProps> = ({
         <div className="mt-[1.8rem]">
           <PostMetaSection {...post.meta} />
 
-          <div className="w-full max-w-none prose-code:text-[.95em] prose-code:font-normal prose-a:underline-offset-2 prose-code:before:content-none prose-code:after:content-none prose-code:bg-transparent prose-code:border-none prose hover:prose-a:text-violet focus:prose-a:text-violet prose-code:text-violet-code prose-code:font-code">
+          <div className="prose-code:text-[.95em] prose-code:font-normal prose-a:underline-offset-2 prose-code:before:content-none prose-code:after:content-none prose-code:bg-transparent prose-code:border-none prose hover:prose-a:text-violet focus:prose-a:text-violet prose-code:text-violet-code prose-code:font-code w-full max-w-none">
             <MDXRemote {...post.content} components={blogAllowedComponents} />
           </div>
         </div>

--- a/apps/labs/pages/blog/index.tsx
+++ b/apps/labs/pages/blog/index.tsx
@@ -145,9 +145,9 @@ const BlogListPage: FC<BlogListPageProps> = ({
           {(blok: TRawBlok) => <BlokProvider blok={blok} />}
         </Page>
       )}
-      <div className="pt-[3rem] pb-[12.2rem] mx-auto w-[95%] max-w-[83rem] md:w-[85%] xl:w-[70%]">
+      <div className="mx-auto w-[95%] max-w-[83rem] pb-[12.2rem] pt-[3rem] md:w-[85%] xl:w-[70%]">
         {data.content.title && (
-          <h2 className="text-[2.4rem] font-extrabold leading-[4.9rem] text-heading text-violet">
+          <h2 className="text-heading text-violet text-[2.4rem] font-extrabold leading-[4.9rem]">
             {data.content.title}
           </h2>
         )}
@@ -170,7 +170,7 @@ const BlogListPage: FC<BlogListPageProps> = ({
             return (
               <div
                 key={post.slug}
-                className="odd:mr-[2%] mb-[3.7rem] w-full md:w-[49%]"
+                className="mb-[3.7rem] w-full odd:mr-[2%] md:w-[49%]"
               >
                 <PostListItem post={post} variant="vertical" />
               </div>
@@ -212,7 +212,6 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
   const { items } = await getAllPosts(preview);
   const data = await getPage({ slug: 'blog', relations: '' }, preview);
 
-  
   /* TODO: RSS build is broken and needs fixing */
   // await generateRSS(items);
 

--- a/apps/labs/pages/opt-out-analytics.tsx
+++ b/apps/labs/pages/opt-out-analytics.tsx
@@ -1,7 +1,7 @@
 import { OptOutAnalytics } from '@quansight/shared/ui-components';
 
 export const OptOutAnalyticsPage = () => (
-  <div className="mx-auto prose">
+  <div className="prose mx-auto">
     <OptOutAnalytics domain="labs.quansight.org" />
     <hr />
     <p>

--- a/libs/shared/ui-components/src/Button/Button.tsx
+++ b/libs/shared/ui-components/src/Button/Button.tsx
@@ -19,7 +19,7 @@ export const Button: FC<TButtonProps> = ({
       {...buttonProps}
       onClick={onClick}
       className={clsx(
-        'py-4 px-12 w-fit text-[1.6rem] font-bold leading-[3.7rem] text-white bg-violet',
+        'bg-violet w-fit px-12 py-4 text-[1.6rem] font-bold leading-[3.7rem] text-white',
         className,
       )}
     >

--- a/libs/shared/ui-components/src/ButtonLink/ButtonLink.tsx
+++ b/libs/shared/ui-components/src/ButtonLink/ButtonLink.tsx
@@ -16,7 +16,7 @@ export const ButtonLink: FC<TButtonLinkProps> = ({
   <Link href={url}>
     <a
       className={clsx(
-        'flex justify-start items-center py-4 px-12 w-fit text-[1.6rem] font-bold leading-[3.7rem]',
+        'flex w-fit items-center justify-start px-12 py-4 text-[1.6rem] font-bold leading-[3.7rem]',
         color === ButtonColor.Pink && 'text-pink',
         color === ButtonColor.Violet && 'text-violet',
         color === ButtonColor.White && 'text-white',
@@ -31,7 +31,7 @@ export const ButtonLink: FC<TButtonLinkProps> = ({
       {isTriangle && (
         <span
           className={clsx(
-            'inline-block ml-4 w-0 h-0 border-y-8 border-l-8 border-y-transparent border-y-solid border-l-solid',
+            'border-y-solid border-l-solid ml-4 inline-block h-0 w-0 border-y-8 border-l-8 border-y-transparent',
             color === ButtonColor.Pink && 'border-l-pink',
             color === ButtonColor.Violet && 'border-l-violet',
             color === ButtonColor.White && 'bordel-l-white',

--- a/libs/shared/ui-components/src/ColumnArticle/ColumnArticle.tsx
+++ b/libs/shared/ui-components/src/ColumnArticle/ColumnArticle.tsx
@@ -19,7 +19,7 @@ export const ColumnArticle: FC<TColumnArticleProps> = ({
   const headerLevelModifier = header ? 1 : 0;
 
   return (
-    <article className="py-[8rem] px-[2.2rem] mx-auto sm:px-[4.3rem] xl:px-[18rem] max-w-layout">
+    <article className="max-w-layout mx-auto px-[2.2rem] py-[8rem] sm:px-[4.3rem] xl:px-[18rem]">
       {header && (
         <header className="mb-[2.5rem]">
           <ColumnArticleHeader header={header} level={2} />
@@ -47,10 +47,10 @@ export const ColumnArticle: FC<TColumnArticleProps> = ({
         <section
           className={clsx(
             columnClass,
-            'flex order-2 justify-center items-center w-[100%] md:order-4',
+            'order-2 flex w-[100%] items-center justify-center md:order-4',
           )}
         >
-          <div className="relative w-4/5 h-4/5 min-h-[240px]">
+          <div className="relative h-4/5 min-h-[240px] w-4/5">
             <Picture
               imageSrc={imageSrc}
               imageAlt={imageAlt}

--- a/libs/shared/ui-components/src/Footer/Footer.tsx
+++ b/libs/shared/ui-components/src/Footer/Footer.tsx
@@ -9,8 +9,8 @@ export const Footer: FC<TFooterProps> = ({
   policyAndConditions,
   copyright,
 }) => (
-  <footer className="flex justify-center items-center text-black bg-white xl:text-[#efefef] xl:bg-black">
-    <div className="px-9 pt-24 pb-20 w-full sm:px-16 sm:pb-5 xl:px-52 xl:pt-[6.2rem] xl:pb-[3.7rem] max-w-layout">
+  <footer className="flex items-center justify-center bg-white text-black xl:bg-black xl:text-[#efefef]">
+    <div className="max-w-layout w-full px-9 pb-20 pt-24 sm:px-16 sm:pb-5 xl:px-52 xl:pb-[3.7rem] xl:pt-[6.2rem]">
       <section className="grid grid-cols-2 gap-[3.2rem] sm:gap-24 lg:grid-cols-4 lg:gap-[3rem] xl:gap-[8rem]">
         {columns.map((column) => (
           <FooterColumnProvider data={column} key={column._uid} />

--- a/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterContact.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterContact.tsx
@@ -13,8 +13,8 @@ export const FooterContact: FC<TFooterContactProps> = ({
   buttonText,
   buttonLink,
 }) => (
-  <div className="flex flex-col col-span-2 sm:col-span-1">
-    <h2 className="order-2 mb-4 text-[1.6rem] font-bold leading-[3rem] border-black sm:order-1 sm:pb-[1.3rem] sm:border-b-[0.5px] xl:border-white">
+  <div className="col-span-2 flex flex-col sm:col-span-1">
+    <h2 className="order-2 mb-4 border-black text-[1.6rem] font-bold leading-[3rem] sm:order-1 sm:border-b-[0.5px] sm:pb-[1.3rem] xl:border-white">
       {title}
     </h2>
     <div
@@ -23,9 +23,9 @@ export const FooterContact: FC<TFooterContactProps> = ({
     />
     {buttonText && buttonLink && (
       <Link href={`/${buttonLink.cached_url}#${BOOK_A_CALL_FORM_ID}`}>
-        <a className="flex order-1 justify-center items-center py-4 px-12 mb-12 w-full text-[1.6rem] font-bold leading-[3.7rem] border-2 border-black sm:order-3 sm:mt-12 sm:mb-0 xl:border-white">
+        <a className="order-1 mb-12 flex w-full items-center justify-center border-2 border-black px-12 py-4 text-[1.6rem] font-bold leading-[3.7rem] sm:order-3 sm:mb-0 sm:mt-12 xl:border-white">
           {buttonText}
-          <span className="inline-block ml-4 w-0 h-0 border-y-8 border-l-8 border-black border-y-transparent xl:border-white xl:border-y-black border-y-solid border-l-solid" />
+          <span className="border-y-solid border-l-solid ml-4 inline-block h-0 w-0 border-y-8 border-l-8 border-black border-y-transparent xl:border-white xl:border-y-black" />
         </a>
       </Link>
     )}

--- a/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterLogo.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterLogo.tsx
@@ -21,7 +21,7 @@ export const FooterLogo: FC<TFooterLogoProps> = ({
   }, [deviceSize]);
 
   return (
-    <div className="relative top-0 w-[23.9rem] h-[6.455rem] sm:w-[22.6rem] sm:h-[6.104rem]">
+    <div className="relative top-0 h-[6.455rem] w-[23.9rem] sm:h-[6.104rem] sm:w-[22.6rem]">
       <Picture
         imageSrc={logo.filename}
         imageAlt={logo.alt}

--- a/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterNavigation.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterNavigation.tsx
@@ -8,7 +8,7 @@ export const FooterNavigation: FC<TFooterNavigationProps> = ({
   links,
 }) => (
   <div className="mb-8">
-    <h2 className="pb-[1.3rem] mb-4 text-[1.6rem] font-bold leading-[3rem] border-b-[0.5px] border-black xl:border-white">
+    <h2 className="mb-4 border-b-[0.5px] border-black pb-[1.3rem] text-[1.6rem] font-bold leading-[3rem] xl:border-white">
       {title}
     </h2>
     <div className="flex flex-col">

--- a/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterSocialMedia.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterColumnProvider/FooterSocialMedia.tsx
@@ -8,7 +8,7 @@ export const FooterSocialMedia: FC<TFooterSocialMediaProps> = ({
   links,
 }) => (
   <div className="col-span-2 sm:col-span-1">
-    <h2 className="hidden pb-[1.3rem] mb-8 text-[1.6rem] font-bold leading-[3rem] border-b-[0.5px] border-black sm:block xl:border-white">
+    <h2 className="mb-8 hidden border-b-[0.5px] border-black pb-[1.3rem] text-[1.6rem] font-bold leading-[3rem] sm:block xl:border-white">
       {title}
     </h2>
     <ul className="flex flex-wrap gap-12 lg:gap-8 xl:gap-12">

--- a/libs/shared/ui-components/src/Footer/FooterCopyright.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterCopyright.tsx
@@ -7,9 +7,9 @@ export const FooterCopyright: FC<TFooterCopyrightProps> = ({
   policyAndConditions,
   copyright,
 }) => (
-  <section className="items-center pt-8 mt-[3.7rem] border-t-[0.5px] border-black sm:flex sm:gap-[2.7rem] sm:mt-[8.5rem] xl:border-white">
+  <section className="mt-[3.7rem] items-center border-t-[0.5px] border-black pt-8 sm:mt-[8.5rem] sm:flex sm:gap-[2.7rem] xl:border-white">
     {policyAndConditions?.length > 0 && (
-      <ul className="flex gap-[2.4rem] justify-start items-center sm:gap-[2.7rem]">
+      <ul className="flex items-center justify-start gap-[2.4rem] sm:gap-[2.7rem]">
         {policyAndConditions.map((link) => (
           <li key={link._uid}>
             <FooterLink {...link} className="text-[1.2rem] leading-[2.4rem]" />

--- a/libs/shared/ui-components/src/Footer/FooterLink/FooterLink.tsx
+++ b/libs/shared/ui-components/src/Footer/FooterLink/FooterLink.tsx
@@ -18,7 +18,7 @@ export const FooterLink: FC<TFooterLinkProps> = ({
     <FooterLinkWrapper linkUrl={linkUrl} queryString={queryString} {...props}>
       {isTextPresent ? (
         isIconPreset ? (
-          <span className="block relative w-10 h-10 brightness-0 lg:w-8 lg:h-8 xl:w-10 xl:h-10 xl:brightness-100">
+          <span className="relative block h-10 w-10 brightness-0 lg:h-8 lg:w-8 xl:h-10 xl:w-10 xl:brightness-100">
             <span className="sr-only">{linkText}</span>
             <Picture
               aria-hidden={true}

--- a/libs/shared/ui-components/src/Form/Form.tsx
+++ b/libs/shared/ui-components/src/Form/Form.tsx
@@ -59,9 +59,9 @@ export const Form: FC<TFormProps> = (props) => {
     <div
       id={BOOK_A_CALL_FORM_ID}
       className={clsx(
-        'relative py-[4.1rem] my-[6rem] mx-auto max-w-layout',
+        'max-w-layout relative mx-auto my-[6rem] py-[4.1rem]',
         'md:flex md:items-center md:py-[6rem]',
-        'xl:py-[8rem] xl:my-[8rem]',
+        'xl:my-[8rem] xl:py-[8rem]',
         backgroundStyles,
       )}
     >
@@ -109,7 +109,7 @@ export const Form: FC<TFormProps> = (props) => {
           </div>
           <div className="flex justify-center md:justify-end lg:mr-[-3.5rem]">
             <Button
-              className="py-[1.5rem] px-[5rem]"
+              className="px-[5rem] py-[1.5rem]"
               title="Submit"
               type="submit"
               onClick={checkErrors}

--- a/libs/shared/ui-components/src/Form/FormError.tsx
+++ b/libs/shared/ui-components/src/Form/FormError.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 
 export const FormError: FC = () => (
-  <span className="block mt-[.5rem] text-[1.2rem] text-red">
+  <span className="text-red mt-[.5rem] block text-[1.2rem]">
     This field is required
   </span>
 );

--- a/libs/shared/ui-components/src/Form/FormHeader.tsx
+++ b/libs/shared/ui-components/src/Form/FormHeader.tsx
@@ -5,9 +5,9 @@ import { TFormHeaderProps } from './types';
 export const FormHeader: FC<TFormHeaderProps> = ({ title }) => (
   <h2
     className="
-      mb-[5.6rem] text-[4rem] font-extrabold leading-[4.9rem] text-center 
-      md:mb-[6.8rem] md:text-[4.8rem] md:text-left 
-      text-violet font-heading
+      text-violet font-heading mb-[5.6rem] text-center text-[4rem] 
+      font-extrabold leading-[4.9rem] md:mb-[6.8rem] 
+      md:text-left md:text-[4.8rem]
     "
   >
     {title}

--- a/libs/shared/ui-components/src/Form/FormSuccess.tsx
+++ b/libs/shared/ui-components/src/Form/FormSuccess.tsx
@@ -5,8 +5,8 @@ import { TFormSuccessProps } from './types';
 export const FormSuccess: FC<TFormSuccessProps> = ({ thanksMessage }) => (
   <div
     className="
-      relative py-[10.1rem] px-[2.2rem] mx-auto md:py-[12rem] lg:px-[13rem] xl:py-[16rem]
-      max-w-layout
+      max-w-layout relative mx-auto px-[2.2rem] py-[10.1rem] md:py-[12rem] lg:px-[13rem]
+      xl:py-[16rem]
     "
   >
     {thanksMessage.content.map(({ type, content }) => {
@@ -17,9 +17,9 @@ export const FormSuccess: FC<TFormSuccessProps> = ({ thanksMessage }) => (
           <h2
             key={value}
             className="
-              text-[4rem] font-extrabold leading-[5.9rem] text-center 
-              md:text-[4.8rem] 
-              text-violet font-heading
+              text-violet font-heading text-center text-[4rem] 
+              font-extrabold 
+              leading-[5.9rem] md:text-[4.8rem]
             "
           >
             {value}
@@ -29,7 +29,7 @@ export const FormSuccess: FC<TFormSuccessProps> = ({ thanksMessage }) => (
         return (
           <p
             key={value}
-            className="text-[1.8rem] leading-[2.7rem] text-center text-black"
+            className="text-center text-[1.8rem] leading-[2.7rem] text-black"
           >
             {value}
           </p>

--- a/libs/shared/ui-components/src/Header/Common/HeaderLogo.tsx
+++ b/libs/shared/ui-components/src/Header/Common/HeaderLogo.tsx
@@ -15,8 +15,8 @@ export const HeaderLogo: FC<THeaderLogoProps> = ({ logo, domainVariant }) => (
       className={clsx(
         'relative shrink-0',
         domainVariant === DomainVariant.Quansight
-          ? 'w-[20.7rem] h-[6.8rem] sm:w-[24.84rem] sm:h-[8.16rem] lg:w-[31.5rem] lg:h-[10.3rem]'
-          : 'w-[27.3rem] h-[7.373rem] lg:w-[33.5rem] lg:h-[9.49rem]',
+          ? 'h-[6.8rem] w-[20.7rem] sm:h-[8.16rem] sm:w-[24.84rem] lg:h-[10.3rem] lg:w-[31.5rem]'
+          : 'h-[7.373rem] w-[27.3rem] lg:h-[9.49rem] lg:w-[33.5rem]',
       )}
     >
       <Picture

--- a/libs/shared/ui-components/src/Header/Common/HeaderSkipLinks.tsx
+++ b/libs/shared/ui-components/src/Header/Common/HeaderSkipLinks.tsx
@@ -19,8 +19,8 @@ export const HeaderSkipLinks: FC<THeaderSkipLinksProps> = ({
   };
 
   return (
-    <div className="absolute inset-x-0 top-0 z-50 py-[2rem] max-w-full text-[1.6rem] font-extrabold  text-center text-white bg-black transition-transform motion-reduce:transition-none duration-300 ease-in-out -translate-y-full focus-within:translate-y-0">
-      <button onClick={onSkipLinks} className="pb-2 border-b-2 ">
+    <div className="absolute inset-x-0 top-0 z-50 max-w-full -translate-y-full bg-black py-[2rem]  text-center text-[1.6rem] font-extrabold text-white transition-transform duration-300 ease-in-out focus-within:translate-y-0 motion-reduce:transition-none">
+      <button onClick={onSkipLinks} className="border-b-2 pb-2 ">
         {skipLinksText}
       </button>
     </div>

--- a/libs/shared/ui-components/src/Header/Header.tsx
+++ b/libs/shared/ui-components/src/Header/Header.tsx
@@ -31,7 +31,7 @@ export const Header: FC<THeaderProps> = ({
       {process.env['NEXT_PUBLIC_VERCEL_ENV'] !== 'production' && (
         <PreviewModeBanner preview={preview} />
       )}
-      <div className="mx-auto max-w-layout">
+      <div className="max-w-layout mx-auto">
         <HeaderSkipLinks skipLinksText={skipLinksText} />
         {deviceSize === DeviceSizeVariant.Mobile && (
           <HeaderMobile

--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktop.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktop.tsx
@@ -10,7 +10,7 @@ export const HeaderDesktop: FC<THeaderDesktopProps> = ({
   domainVariant,
 }) => {
   return (
-    <div className="hidden gap-[4.7rem] justify-between items-center sm:flex sm:px-[3.4rem] lg:gap-[13.7rem] xl:gap-[15.1rem] xl:px-[11.5rem]">
+    <div className="hidden items-center justify-between gap-[4.7rem] sm:flex sm:px-[3.4rem] lg:gap-[13.7rem] xl:gap-[15.1rem] xl:px-[11.5rem]">
       <HeaderLogo logo={logo} domainVariant={domainVariant} />
       <HeaderDesktopNavigation
         navigation={navigation}

--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigation.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigation.tsx
@@ -14,9 +14,9 @@ export const HeaderDesktopNavigation: FC<THeaderDesktopNavigationProps> = ({
   return (
     <nav
       className={clsx(
-        'flex flex-wrap gap-x-[3rem] gap-y-[1.5rem] items-center w-full xl:gap-[2.7rem] xl:justify-end',
+        'flex w-full flex-wrap items-center gap-x-[3rem] gap-y-[1.5rem] xl:justify-end xl:gap-[2.7rem]',
         domainVariant === DomainVariant.Quansight
-          ? 'justify-start mt-[2.4rem]'
+          ? 'mt-[2.4rem] justify-start'
           : 'justify-end',
       )}
     >

--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdown.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdown.tsx
@@ -58,7 +58,7 @@ export const HeaderDesktopDropdown: FC<THeaderDesktopDropdownProps> = ({
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
         className={clsx(
           isDropdownOpen ? 'text-green' : 'text-white',
-          'flex justify-between items-center text-[1.7rem] font-extrabold leading-[2.825rem] capitalize font-heading',
+          'font-heading flex items-center justify-between text-[1.7rem] font-extrabold capitalize leading-[2.825rem]',
         )}
       >
         {buttonText}
@@ -67,15 +67,15 @@ export const HeaderDesktopDropdown: FC<THeaderDesktopDropdownProps> = ({
           className={clsx(
             isDropdownOpen ? 'rotate-180' : 'rotate-0',
             isDropdownOpen && 'border-y-green',
-            'inline-block ml-4 w-0 h-0 border-x-[0.7rem] border-t-[.7rem] border-x-transparent transition-transform motion-reduce:transition-none ease-in-out border-y-solid border-l-solid',
+            'border-y-solid border-l-solid ml-4 inline-block h-0 w-0 border-x-[0.7rem] border-t-[.7rem] border-x-transparent transition-transform ease-in-out motion-reduce:transition-none',
           )}
         />
       </button>
       {isDropdownOpen && (
-        <div className="absolute top-full right-0 z-20 pt-[2.4rem] w-max max-w-[25rem]">
+        <div className="absolute right-0 top-full z-20 w-max max-w-[25rem] pt-[2.4rem]">
           <ul
             id="options"
-            className="flex flex-col gap-[1.8rem] justify-between items-start p-[2.8rem] min-w-[19.8rem] text-left text-black bg-white"
+            className="flex min-w-[19.8rem] flex-col items-start justify-between gap-[1.8rem] bg-white p-[2.8rem] text-left text-black"
           >
             {links.map((link) => (
               <HeaderDesktopDropdownLink

--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdownLink.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopDropdownLink.tsx
@@ -19,7 +19,7 @@ export const HeaderDesktopDropdownLink: FC<THeaderDesktopDropdownLinkProps> = ({
 
   return (
     <button
-      className="text-[1.7rem] font-normal leading-[2.225rem] text-left hover:underline focus:underline capitalize transition-colors motion-reduce:transition-none ease-in-out font-heading"
+      className="font-heading text-left text-[1.7rem] font-normal capitalize leading-[2.225rem] transition-colors ease-in-out hover:underline focus:underline motion-reduce:transition-none"
       onClick={onButtonClick}
     >
       {linkText}

--- a/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopLink.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderDesktop/HeaderDesktopNavigationProvider/HeaderDesktopLink.tsx
@@ -11,7 +11,7 @@ export const HeaderDesktopLink: FC<THeaderDesktopLinkProps> = ({
   queryParams,
 }) => (
   <Link href={getLinkUrl(queryParams, linkUrl)}>
-    <a className="text-[1.7rem] font-extrabold leading-[2.825rem] capitalize transition-colors motion-reduce:transition-none ease-in-out font-heading hover:text-green">
+    <a className="font-heading hover:text-green text-[1.7rem] font-extrabold capitalize leading-[2.825rem] transition-colors ease-in-out motion-reduce:transition-none">
       {linkText}
     </a>
   </Link>

--- a/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileBookingLink.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileBookingLink.tsx
@@ -27,13 +27,13 @@ export const HeaderMobileBookingLink: FC<TBookingLinkProps> = ({
   return (
     <button
       onClick={onButtonClick}
-      className="inline-block py-[1.6rem] px-[4.4rem] mx-[2rem] mt-[6.8rem] text-[1.7rem] font-extrabold leading-[2.825rem] text-white bg-pink font-heading"
+      className="bg-pink font-heading mx-[2rem] mt-[6.8rem] inline-block px-[4.4rem] py-[1.6rem] text-[1.7rem] font-extrabold leading-[2.825rem] text-white"
     >
-      <div className="flex justify-between items-center">
+      <div className="flex items-center justify-between">
         {bookACallLinkText}
         <span
           aria-hidden="true"
-          className="inline-block ml-4 w-0 h-0 border-y-8 border-l-8 border-y-transparent border-y-solid border-l-solid"
+          className="border-y-solid border-l-solid ml-4 inline-block h-0 w-0 border-y-8 border-l-8 border-y-transparent"
         />
       </div>
     </button>

--- a/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileMenu/HeaderMobileMenu.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileMenu/HeaderMobileMenu.tsx
@@ -38,7 +38,7 @@ export const HeaderMobileMenu: FC<THeaderMobileMenuProps> = ({
     <div
       ref={container}
       className={clsx(
-        'flex absolute z-40 justify-between items-center py-[0.5rem] px-[2rem] w-full transition-all motion-reduce:transition-none duration-300 ease-in-out',
+        'absolute z-40 flex w-full items-center justify-between px-[2rem] py-[0.5rem] transition-all duration-300 ease-in-out motion-reduce:transition-none',
         !menuBackground && domainVariant === DomainVariant.Quansight
           ? 'bg-transparent'
           : 'bg-black',

--- a/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileMenu/HeaderMobileMenuButton.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileMenu/HeaderMobileMenuButton.tsx
@@ -12,20 +12,20 @@ export const HeaderMobileMenuButton: FC<THeaderMobileMenuButtonProps> = ({
     aria-expanded={isNavigationOpen ? 'true' : 'false'}
     aria-controls="menu"
     onClick={() => setIsNavigationOpen(!isNavigationOpen)}
-    className="w-[3rem] h-[3rem] cursor-pointer"
+    className="h-[3rem] w-[3rem] cursor-pointer"
   >
     <p className="sr-only">Menu</p>
     <ul
       aria-hidden="true"
-      className="flex overflow-hidden relative flex-col gap-[0.6rem] justify-center items-center w-full h-full"
+      className="relative flex h-full w-full flex-col items-center justify-center gap-[0.6rem] overflow-hidden"
     >
       {[...Array(3).keys()].map((item) => (
         <span
           key={item}
           className={clsx(
-            'block first:absolute last:absolute w-[3rem] h-[0.3rem] bg-white transition-all motion-reduce:transition-none duration-500 ease-in-out first:translate-y-[-0.9rem] last:translate-y-[0.9rem]',
+            'block h-[0.3rem] w-[3rem] bg-white transition-all duration-500 ease-in-out first:absolute first:translate-y-[-0.9rem] last:absolute last:translate-y-[0.9rem] motion-reduce:transition-none',
             isNavigationOpen &&
-              'even:opacity-0 first:rotate-45 last:-rotate-45 even:translate-x-[-2rem] first:translate-y-0 last:translate-y-0',
+              'first:translate-y-0 first:rotate-45 last:translate-y-0 last:-rotate-45 even:translate-x-[-2rem] even:opacity-0',
           )}
         />
       ))}

--- a/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileNavigation.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileNavigation.tsx
@@ -15,14 +15,14 @@ export const HeaderMobileNavigation: FC<THeaderMobileNavigationProps> = ({
 }) => (
   <nav
     className={clsx(
-      'absolute inset-0 z-30 pt-[8rem] w-screen h-screen bg-black transition-transform motion-reduce:transition-none duration-300 ease-in-out',
+      'absolute inset-0 z-30 h-screen w-screen bg-black pt-[8rem] transition-transform duration-300 ease-in-out motion-reduce:transition-none',
       isNavigationOpen ? 'block' : 'hidden',
     )}
   >
-    <div className="overflow-y-auto pb-[5rem] h-full">
+    <div className="h-full overflow-y-auto pb-[5rem]">
       <ul
         id="menu"
-        className="flex flex-col justify-start items-center px-[2rem] pt-[1.8rem]"
+        className="flex flex-col items-center justify-start px-[2rem] pt-[1.8rem]"
       >
         {navigation.map((navigationItem) => (
           <li

--- a/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileNavigationProvider/HeaderMobileDropdown.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileNavigationProvider/HeaderMobileDropdown.tsx
@@ -23,7 +23,7 @@ export const HeaderMobileDropdown: FC<THeaderMobileDropdownProps> = ({
       <button
         aria-expanded={isNavbarItemOpen ? 'true' : 'false'}
         aria-controls="options"
-        className="flex justify-start items-center py-[1.6rem] px-[2rem] w-full text-[1.7rem] font-extrabold leading-[2.825rem] text-left capitalize font-heading"
+        className="font-heading flex w-full items-center justify-start px-[2rem] py-[1.6rem] text-left text-[1.7rem] font-extrabold capitalize leading-[2.825rem]"
         onClick={() => setIsNavbarItemOpen(!isNavbarItemOpen)}
       >
         {buttonText}
@@ -31,7 +31,7 @@ export const HeaderMobileDropdown: FC<THeaderMobileDropdownProps> = ({
           aria-hidden="true"
           className={clsx(
             isNavbarItemOpen && '-rotate-180',
-            'inline-block ml-4 w-0 h-0 border-x-[0.7rem] border-t-[.7rem] border-x-transparent transition-transform motion-reduce:transition-none duration-500 ease-in-out border-y-solid border-l-solid',
+            'border-y-solid border-l-solid ml-4 inline-block h-0 w-0 border-x-[0.7rem] border-t-[.7rem] border-x-transparent transition-transform duration-500 ease-in-out motion-reduce:transition-none',
           )}
         />
       </button>

--- a/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileNavigationProvider/HeaderMobileLink.tsx
+++ b/libs/shared/ui-components/src/Header/HeaderMobile/HeaderMobileNavigationProvider/HeaderMobileLink.tsx
@@ -25,7 +25,7 @@ export const HeaderMobileLink: FC<THeaderMobileLinkProps> = ({
     <button
       onClick={onLinkClick}
       className={clsx(
-        'inline-block px-[2rem] w-full text-[1.7rem] leading-[2.825rem] text-left capitalize font-heading',
+        'font-heading inline-block w-full px-[2rem] text-left text-[1.7rem] capitalize leading-[2.825rem]',
         linkVariant === LinkVariant.Dropdown
           ? 'font-normal'
           : 'py-[1.6rem] font-extrabold',

--- a/libs/shared/ui-components/src/Hero/Hero.tsx
+++ b/libs/shared/ui-components/src/Hero/Hero.tsx
@@ -29,7 +29,7 @@ export const Hero: FC<THeroProps> = ({
   return (
     <div
       className={clsx(
-        'overflow-hidden w-full h-[730px] ',
+        'h-[730px] w-full overflow-hidden ',
         isSmallHero && 'md:h-[29.4rem]',
         isLargeHero && 'md:h-[970px]',
         isMediumHero && 'md:h-[730px]',
@@ -40,7 +40,7 @@ export const Hero: FC<THeroProps> = ({
         !backgroundColor && 'bg-transparent',
       )}
     >
-      <div className="relative mx-auto h-full max-w-layout">
+      <div className="max-w-layout relative mx-auto h-full">
         {imageMobile?.imageSrc &&
         imageTablet?.imageSrc &&
         imageDesktop?.imageSrc ? (
@@ -61,19 +61,19 @@ export const Hero: FC<THeroProps> = ({
         {title && (
           <div
             className={clsx(
-              'relative px-[2rem] placeholder:md:px-0 pt-[13rem] md:absolute md:px-0 md:pt-0',
+              'relative px-[2rem] pt-[13rem] md:absolute md:px-0 md:pt-0 placeholder:md:px-0',
               (isMediumHero || isSmallHero) &&
-                'flex flex-col justify-center items-center w-full h-full',
+                'flex h-full w-full flex-col items-center justify-center',
               isLargeHero &&
-                'md:top-[28rem] md:left-[10%] md:w-[85%] lg:left-[14%] lg:w-1/2',
+                'md:left-[10%] md:top-[28rem] md:w-[85%] lg:left-[14%] lg:w-1/2',
             )}
           >
             <h1
               className={clsx(
-                'font-extrabold leading-[6rem] text-white font-heading',
+                'font-heading font-extrabold leading-[6rem] text-white',
                 isLargeHero
                   ? 'mb-[1.5rem] text-[4rem] md:mb-[4rem] md:text-[5rem]'
-                  : 'text-[5rem] text-center',
+                  : 'text-center text-[5rem]',
               )}
             >
               {title}
@@ -81,7 +81,7 @@ export const Hero: FC<THeroProps> = ({
             {subTitle && (
               <div
                 className={clsx(
-                  'text-[4rem] font-extrabold leading-[4.8rem] text-white font-heading',
+                  'font-heading text-[4rem] font-extrabold leading-[4.8rem] text-white',
                   isLargeHero && 'text-[3rem] md:text-[4rem]',
                   (isMediumHero || isSmallHero) && 'text-center',
                 )}

--- a/libs/shared/ui-components/src/Input/Input.tsx
+++ b/libs/shared/ui-components/src/Input/Input.tsx
@@ -16,7 +16,7 @@ export const Input: FC<TInputProps> = forwardRef<HTMLInputElement, TInputProps>(
         type={type}
         onChange={onChange}
         className={clsx(
-          'p-[15px] w-full text-[1.6rem] leading-[3rem] placeholder:text-black border border-gray-100 border-solid',
+          'w-full border border-solid border-gray-100 p-[15px] text-[1.6rem] leading-[3rem] placeholder:text-black',
           className,
         )}
         {...inputProps}

--- a/libs/shared/ui-components/src/Logos/Logos.tsx
+++ b/libs/shared/ui-components/src/Logos/Logos.tsx
@@ -18,15 +18,15 @@ export const Logos: FC<TLogosProps> = ({
   return (
     <section
       className="
-        flex flex-col items-center py-[4rem] px-[3rem] mx-auto text-center 
-        md:py-[6.5rem] md:px-[13rem]
-        max-w-layout
+        max-w-layout mx-auto flex flex-col items-center px-[3rem] py-[4rem] 
+        text-center md:px-[13rem]
+        md:py-[6.5rem]
       "
     >
       {title && (
         <h2
           className={clsx(
-            'relative mx-auto max-w-[65rem] leading-[3.5rem] z-1 font-heading',
+            'z-1 font-heading relative mx-auto max-w-[65rem] leading-[3.5rem]',
             colorVariant === LogosColors.White &&
               'hidden pb-[2rem] text-[2.2rem] text-white md:block',
             colorVariant === LogosColors.Black &&

--- a/libs/shared/ui-components/src/Logos/LogosGrid.tsx
+++ b/libs/shared/ui-components/src/Logos/LogosGrid.tsx
@@ -6,7 +6,7 @@ import { Picture } from '../Picture/Picture';
 import { TLogosGridProps } from './types';
 
 export const LogosGrid: FC<TLogosGridProps> = ({ grid }) => (
-  <ul className="flex flex-wrap gap-y-[2rem] justify-center w-full md:gap-y-[3rem]">
+  <ul className="flex w-full flex-wrap justify-center gap-y-[2rem] md:gap-y-[3rem]">
     {grid.map(({ imageSrc, imageAlt }) => (
       <li
         key={imageAlt}
@@ -15,7 +15,7 @@ export const LogosGrid: FC<TLogosGridProps> = ({ grid }) => (
           grid.length === 6 ? 'lg:w-2/12' : 'lg:w-1/5',
         )}
       >
-        <div className="relative w-auto h-[5.3rem]">
+        <div className="relative h-[5.3rem] w-auto">
           <Picture
             imageSrc={imageSrc}
             imageAlt={imageAlt}

--- a/libs/shared/ui-components/src/PreviewModeBanner/PreviewModeBanner.tsx
+++ b/libs/shared/ui-components/src/PreviewModeBanner/PreviewModeBanner.tsx
@@ -27,7 +27,7 @@ export const PreviewModeBanner: FC<TPreviewModeBannerProps> = ({ preview }) => {
   const gitRef = process.env['NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF'];
   const githubBranchLink = (
     <a
-      className="underline transition-colors duration-200 hover:text-pink"
+      className="hover:text-pink underline transition-colors duration-200"
       href={`https://github.com/Quansight/Quansight-website/tree/${gitRef}`}
     >
       {gitRef}
@@ -65,7 +65,7 @@ export const PreviewModeBanner: FC<TPreviewModeBannerProps> = ({ preview }) => {
       {preview ? (
         <details>
           <summary>Preview</summary>
-          <ul className="list-disc list-inside">
+          <ul className="list-inside list-disc">
             <li>
               This page is in content preview mode. You can see{' '}
               <strong>draft</strong> content.
@@ -74,7 +74,7 @@ export const PreviewModeBanner: FC<TPreviewModeBannerProps> = ({ preview }) => {
               {showExitPreviewLink ? (
                 <a
                   href="/api/exit-preview"
-                  className="underline transition-colors duration-200 hover:text-pink"
+                  className="hover:text-pink underline transition-colors duration-200"
                 >
                   Exit content preview mode.
                 </a>
@@ -93,14 +93,14 @@ export const PreviewModeBanner: FC<TPreviewModeBannerProps> = ({ preview }) => {
       ) : (
         <details>
           <summary>Preview</summary>
-          <ul className="list-disc list-inside">
+          <ul className="list-inside list-disc">
             <li>
               You are seeing only <strong>published</strong> content.
             </li>
             <li>
               <a
                 href="/api/enter-preview"
-                className="underline transition-colors duration-200 hover:text-pink"
+                className="hover:text-pink underline transition-colors duration-200"
               >
                 Enter content preview mode
               </a>{' '}

--- a/libs/shared/ui-components/src/Statute/Statute.tsx
+++ b/libs/shared/ui-components/src/Statute/Statute.tsx
@@ -4,9 +4,9 @@ import { StatuteSection } from './StatuteSection';
 import { TStatuteProps } from './types';
 
 export const Statute: FC<TStatuteProps> = ({ title, sections }) => (
-  <article className="py-[5.4rem] px-[1.8rem] mx-auto sm:py-[6.4rem] sm:px-[4.4rem] xl:px-[21.2rem] xl:pt-[11.2rem] xl:pb-[8.6rem] max-w-layout">
-    <div className="pb-[7.6rem] border-b border-gray-100 sm:pb-[8.6rem] xl:pb-[12.6rem]">
-      <h2 className="mb-[8.6rem] text-[4rem] font-extrabold leading-[4.9rem] text-center sm:mx-auto sm:max-w-[70rem] sm:text-[4.8rem] sm:leading-[5.3rem] xl:mb-[12.4rem] font-heading text-violet">
+  <article className="max-w-layout mx-auto px-[1.8rem] py-[5.4rem] sm:px-[4.4rem] sm:py-[6.4rem] xl:px-[21.2rem] xl:pb-[8.6rem] xl:pt-[11.2rem]">
+    <div className="border-b border-gray-100 pb-[7.6rem] sm:pb-[8.6rem] xl:pb-[12.6rem]">
+      <h2 className="font-heading text-violet mb-[8.6rem] text-center text-[4rem] font-extrabold leading-[4.9rem] sm:mx-auto sm:max-w-[70rem] sm:text-[4.8rem] sm:leading-[5.3rem] xl:mb-[12.4rem]">
         {title}
       </h2>
       {sections.map((section) => (

--- a/libs/shared/ui-components/src/Statute/StatuteSection.tsx
+++ b/libs/shared/ui-components/src/Statute/StatuteSection.tsx
@@ -6,12 +6,12 @@ import { TStatuteSectionProps } from './types';
 
 export const StatuteSection: FC<TStatuteSectionProps> = ({ title, text }) => {
   return (
-    <section className="px-[1.8rem] mb-[4.1rem] last:mb-0 xl:px-[4.4rem]">
-      <h3 className="mb-[1.8rem] text-[2.7rem] font-extrabold leading-[3.5rem] text-black sm:mb-[2.2rem] sm:text-[3.2rem] xl:mb-[2.5rem] xl:leading-[5.3rem] font-heading">
+    <section className="mb-[4.1rem] px-[1.8rem] last:mb-0 xl:px-[4.4rem]">
+      <h3 className="font-heading mb-[1.8rem] text-[2.7rem] font-extrabold leading-[3.5rem] text-black sm:mb-[2.2rem] sm:text-[3.2rem] xl:mb-[2.5rem] xl:leading-[5.3rem]">
         {title}
       </h3>
       <div
-        className="min-w-full text-[1.6rem] text-black marker:text-black prose sm:text-[1.8rem] xl:leading-[2.7rem]"
+        className="prose min-w-full text-[1.6rem] text-black marker:text-black sm:text-[1.8rem] xl:leading-[2.7rem]"
         dangerouslySetInnerHTML={createMarkup(text)}
       />
     </section>

--- a/libs/shared/ui-components/src/Team/Team.tsx
+++ b/libs/shared/ui-components/src/Team/Team.tsx
@@ -22,11 +22,11 @@ export const Team: FC<TTeamProps> = ({
   const needHeadingSpace = checkNamesOverflow(teamToDisplay);
 
   return (
-    <section className="px-[1.8rem] my-[6rem] mx-auto md:my-[8rem] lg:px-[3rem] xl:px-[18rem] max-w-layout">
+    <section className="max-w-layout mx-auto my-[6rem] px-[1.8rem] md:my-[8rem] lg:px-[3rem] xl:px-[18rem]">
       <h2
         className="
-          text-[4rem] font-extrabold leading-[4.9rem] text-center md:text-[4.8rem]
-          text-violet font-heading
+          text-violet font-heading text-center text-[4rem] font-extrabold
+          leading-[4.9rem] md:text-[4.8rem]
         "
       >
         {header}

--- a/libs/shared/ui-components/src/Team/TeamMember/TeamMember.tsx
+++ b/libs/shared/ui-components/src/Team/TeamMember/TeamMember.tsx
@@ -24,7 +24,7 @@ export const TeamMember: FC<TTeamMemberComponent> = (teamMember) => {
   `;
 
   return (
-    <li className="box-border px-[1.25rem] w-1/2 md:mb-[3rem] md:w-1/5">
+    <li className="box-border w-1/2 px-[1.25rem] md:mb-[3rem] md:w-1/5">
       <TeamMemberName name={teamMemberName} />
       {image && <TeamMemberImage image={image} shape={shape} />}
       {githubNick && <TeamMemberGithub nick={githubNick} />}

--- a/libs/shared/ui-components/src/Team/TeamMember/TeamMemberImage.tsx
+++ b/libs/shared/ui-components/src/Team/TeamMember/TeamMemberImage.tsx
@@ -11,7 +11,7 @@ export type TTeamMemberImage = {
 };
 
 export const TeamMemberImage: FC<TTeamMemberImage> = ({ image, shape }) => (
-  <div className="flex relative mb-[0.5rem] md:mb-[1rem]">
+  <div className="relative mb-[0.5rem] flex md:mb-[1rem]">
     <Picture
       className="brightness-110 grayscale"
       imageSrc={image.filename}
@@ -20,6 +20,6 @@ export const TeamMemberImage: FC<TTeamMemberImage> = ({ image, shape }) => (
       height={shape === TeamShape.Square ? 200 : 280}
       objectFit="cover"
     />
-    <span className="absolute top-0 left-0 w-full h-full opacity-25 z-2 bg-violet" />
+    <span className="z-2 bg-violet absolute left-0 top-0 h-full w-full opacity-25" />
   </div>
 );

--- a/libs/shared/ui-components/src/Teaser/Teaser.tsx
+++ b/libs/shared/ui-components/src/Teaser/Teaser.tsx
@@ -16,18 +16,18 @@ export const Teaser: FC<TTeaserProps> = ({
   buttonText,
   buttonLink,
 }) => (
-  <div className={`relative max-w-layout mx-auto my-[6rem] lg:my-[7.6rem]`}>
+  <div className={`max-w-layout relative mx-auto my-[6rem] lg:my-[7.6rem]`}>
     <div
       className={clsx(
-        'py-[9.2rem] px-[2.4rem] lg:pt-[11.8rem] lg:pr-[34rem] lg:pl-[13rem] lg:w-3/4 xl:pr-[38rem]',
-        color === TeaserColor.Green && 'text-black bg-green',
-        color === TeaserColor.Violet && 'text-white bg-violet',
-        color === TeaserColor.Pink && 'text-white bg-pink',
+        'px-[2.4rem] py-[9.2rem] lg:w-3/4 lg:pl-[13rem] lg:pr-[34rem] lg:pt-[11.8rem] xl:pr-[38rem]',
+        color === TeaserColor.Green && 'bg-green text-black',
+        color === TeaserColor.Violet && 'bg-violet text-white',
+        color === TeaserColor.Pink && 'bg-pink text-white',
       )}
     >
       <h2
         className={`
-          w-full max-w-[440px] mb-[6.4rem] font-extrabold text-[4rem] leading-[4.9rem]
+          mb-[6.4rem] w-full max-w-[440px] text-[4rem] font-extrabold leading-[4.9rem]
           lg:mb-[2.6rem] lg:text-[4.8rem]
         `}
       >
@@ -41,7 +41,7 @@ export const Teaser: FC<TTeaserProps> = ({
       <div
         className={`
           w-full text-center
-          lg:absolute lg:w-2/5 lg:top-1/2 lg:right-32 lg:-translate-y-1/2
+          lg:absolute lg:right-32 lg:top-1/2 lg:w-2/5 lg:-translate-y-1/2
         `}
       >
         <Picture

--- a/libs/shared/ui-components/src/Textarea/Textarea.tsx
+++ b/libs/shared/ui-components/src/Textarea/Textarea.tsx
@@ -16,7 +16,7 @@ export const Textarea: FC<TTextareaProps> = forwardRef<
       ref={ref}
       onChange={onChange}
       className={clsx(
-        'p-[15px] w-full text-[1.6rem] leading-[3rem] placeholder:text-black border border-gray-100 border-solid',
+        'w-full border border-solid border-gray-100 p-[15px] text-[1.6rem] leading-[3rem] placeholder:text-black',
         className,
       )}
       {...textareaProps}

--- a/libs/shared/utils/src/createMarkup/richTextBlokResolver/components/ErrorNotification/ErrorNotificatoin.tsx
+++ b/libs/shared/utils/src/createMarkup/richTextBlokResolver/components/ErrorNotification/ErrorNotificatoin.tsx
@@ -6,7 +6,7 @@ import { TErrorNotificationProps } from './types';
 export const ErrorNotificatoin: FC<TErrorNotificationProps> = ({
   componentName,
 }) => (
-  <p className="text-[1.6rem] text-center text-red">
+  <p className="text-red text-center text-[1.6rem]">
     {isValidString(componentName)
       ? `The component ${componentName} has not been created yet.`
       : 'Storybook data not received.'}

--- a/libs/shared/utils/src/createMarkup/richTextBlokResolver/richTextBloks/RichTextFigure/RichTextFigure.tsx
+++ b/libs/shared/utils/src/createMarkup/richTextBlokResolver/richTextBloks/RichTextFigure/RichTextFigure.tsx
@@ -7,9 +7,9 @@ export const RichTextFigure: FC<TRichTextFigureProps> = ({
   imageAlt,
   caption,
 }) => (
-  <figure className="flex flex-col justify-center items-center">
+  <figure className="flex flex-col items-center justify-center">
     <img src={imageSrc} alt={imageAlt} />
-    <figcaption className="text-[1.5rem] italic font-normal leading-[2.7rem] text-center">
+    <figcaption className="text-center text-[1.5rem] font-normal italic leading-[2.7rem]">
       {caption}
     </figcaption>
   </figure>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@code-hike/mdx": "^0.5.1-next.0",
         "@nrwl/next": "13.8.5",
-        "@tailwindcss/typography": "^0.5.2",
+        "@tailwindcss/typography": "^0.5.9",
         "axios": "0.27.2",
         "clsx": "^1.2.1",
         "core-js": "^3.25.1",
@@ -80,7 +80,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "7.27.0",
         "eslint-plugin-react-hooks": "4.3.0",
-        "eslint-plugin-tailwindcss": "^3.5.0",
+        "eslint-plugin-tailwindcss": "^3.11.0",
         "husky": "^8.0.1",
         "jest": "27.2.3",
         "lint-staged": "^13.0.3",
@@ -93,7 +93,7 @@
         "stylelint": "^14.3.0",
         "stylelint-config-prettier": "^9.0.3",
         "stylelint-config-standard": "^24.0.0",
-        "tailwindcss": "^3.0.23",
+        "tailwindcss": "^3.3.1",
         "ts-jest": "27.1.3",
         "typescript": "~4.5.2"
       }
@@ -11287,16 +11287,17 @@
       }
     },
     "node_modules/@tailwindcss/typography": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.2.tgz",
-      "integrity": "sha512-coq8DBABRPFcVhVIk6IbKyyHUt7YTEC/C992tatFB+yEx5WGBQrCgsSFjxHUr8AWXphWckadVJbominEduYBqw==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.9.tgz",
+      "integrity": "sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==",
       "dependencies": {
         "lodash.castarray": "^4.4.0",
         "lodash.isplainobject": "^4.0.6",
-        "lodash.merge": "^4.6.2"
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
       },
       "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || insiders"
+        "tailwindcss": ">=3.0.0 || insiders"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -12431,27 +12432,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-node": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
-      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
-      "dependencies": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "node_modules/acorn-node/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/acorn-walk": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -12612,6 +12592,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -15312,11 +15297,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -15385,22 +15365,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
-    },
-    "node_modules/detective": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
-      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
-      "dependencies": {
-        "acorn-node": "^1.8.2",
-        "defined": "^1.0.0",
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "detective": "bin/detective.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -16544,17 +16508,19 @@
       }
     },
     "node_modules/eslint-plugin-tailwindcss": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.5.2.tgz",
-      "integrity": "sha512-CW/Whm8KIC/8Pe68Q0YD9EmFa34r+Z3lkjAIj7vsKEg9ZvDVSOCJkerqePPkaK9ilRxpuGok0TCqWu1OfxE6Qw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.11.0.tgz",
+      "integrity": "sha512-RaraOG4D6VXutKnoNvFQ4+frTWGJDKtezy1yCrGFS7Um1to/npDNdh2GL19IRoGB/eanbtwhxFXy+xyEw0grAg==",
       "dev": true,
       "dependencies": {
         "fast-glob": "^3.2.5",
-        "postcss": "^8.4.4",
-        "tailwindcss": "^3.0.7"
+        "postcss": "^8.4.4"
       },
       "engines": {
         "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.2.2"
       }
     },
     "node_modules/eslint-scope": {
@@ -17163,9 +17129,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -22100,6 +22066,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
+      "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
@@ -25302,6 +25276,16 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -26855,11 +26839,11 @@
       }
     },
     "node_modules/postcss-nested": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
-      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.0.tgz",
+      "integrity": "sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.6"
+        "postcss-selector-parser": "^6.0.10"
       },
       "engines": {
         "node": ">=12.0"
@@ -29789,6 +29773,78 @@
         "node": ">= 8"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.32.0.tgz",
+      "integrity": "sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/sucrase/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sucrase/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sugar": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sugar/-/sugar-1.4.1.tgz",
@@ -30054,32 +30110,34 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.4.tgz",
-      "integrity": "sha512-NrxbFV4tYsga/hpWbRyUfIaBrNMXDxx5BsHgBS4v5tlyjf+sDsgBg5m9OxjrXIqAS/uR9kicxLKP+bEHI7BSeQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.1.tgz",
+      "integrity": "sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==",
       "dependencies": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
-        "detective": "^5.2.1",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.11",
+        "fast-glob": "^3.2.12",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "lilconfig": "^2.0.5",
+        "jiti": "^1.17.2",
+        "lilconfig": "^2.0.6",
+        "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.14",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
-        "postcss-nested": "5.0.6",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-nested": "6.0.0",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
-        "resolve": "^1.22.0"
+        "resolve": "^1.22.1",
+        "sucrase": "^3.29.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
@@ -30108,6 +30166,14 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/tailwindcss/node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tailwindcss/node_modules/postcss-import": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
@@ -30122,6 +30188,18 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tailwindcss/node_modules/quick-lru": {
@@ -30281,6 +30359,25 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/throat": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
@@ -30413,6 +30510,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
@@ -40536,13 +40638,14 @@
       }
     },
     "@tailwindcss/typography": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.2.tgz",
-      "integrity": "sha512-coq8DBABRPFcVhVIk6IbKyyHUt7YTEC/C992tatFB+yEx5WGBQrCgsSFjxHUr8AWXphWckadVJbominEduYBqw==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.9.tgz",
+      "integrity": "sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==",
       "requires": {
         "lodash.castarray": "^4.4.0",
         "lodash.isplainobject": "^4.0.6",
-        "lodash.merge": "^4.6.2"
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
       }
     },
     "@testing-library/dom": {
@@ -41489,23 +41592,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "requires": {}
     },
-    "acorn-node": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
-      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
-      "requires": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
-        }
-      }
-    },
     "acorn-walk": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -41616,6 +41702,11 @@
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
       "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
       "dev": true
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "anymatch": {
       "version": "3.1.2",
@@ -43621,11 +43712,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -43672,16 +43758,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
-    },
-    "detective": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
-      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
-      "requires": {
-        "acorn-node": "^1.8.2",
-        "defined": "^1.0.0",
-        "minimist": "^1.2.6"
-      }
     },
     "didyoumean": {
       "version": "1.2.2",
@@ -44610,14 +44686,13 @@
       "requires": {}
     },
     "eslint-plugin-tailwindcss": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.5.2.tgz",
-      "integrity": "sha512-CW/Whm8KIC/8Pe68Q0YD9EmFa34r+Z3lkjAIj7vsKEg9ZvDVSOCJkerqePPkaK9ilRxpuGok0TCqWu1OfxE6Qw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.11.0.tgz",
+      "integrity": "sha512-RaraOG4D6VXutKnoNvFQ4+frTWGJDKtezy1yCrGFS7Um1to/npDNdh2GL19IRoGB/eanbtwhxFXy+xyEw0grAg==",
       "dev": true,
       "requires": {
         "fast-glob": "^3.2.5",
-        "postcss": "^8.4.4",
-        "tailwindcss": "^3.0.7"
+        "postcss": "^8.4.4"
       }
     },
     "eslint-scope": {
@@ -44963,9 +45038,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -48570,6 +48645,11 @@
         }
       }
     },
+    "jiti": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
+      "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg=="
+    },
     "jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
@@ -50829,6 +50909,16 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -51904,11 +51994,11 @@
       }
     },
     "postcss-nested": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
-      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.0.tgz",
+      "integrity": "sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==",
       "requires": {
-        "postcss-selector-parser": "^6.0.6"
+        "postcss-selector-parser": "^6.0.10"
       }
     },
     "postcss-normalize-charset": {
@@ -54076,6 +54166,58 @@
         "normalize-path": "^3.0.0"
       }
     },
+    "sucrase": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.32.0.tgz",
+      "integrity": "sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==",
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+          "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
     "sugar": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sugar/-/sugar-1.4.1.tgz",
@@ -54270,32 +54412,34 @@
       }
     },
     "tailwindcss": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.4.tgz",
-      "integrity": "sha512-NrxbFV4tYsga/hpWbRyUfIaBrNMXDxx5BsHgBS4v5tlyjf+sDsgBg5m9OxjrXIqAS/uR9kicxLKP+bEHI7BSeQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.1.tgz",
+      "integrity": "sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==",
       "requires": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
-        "detective": "^5.2.1",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.11",
+        "fast-glob": "^3.2.12",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "lilconfig": "^2.0.5",
+        "jiti": "^1.17.2",
+        "lilconfig": "^2.0.6",
+        "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.14",
+        "postcss": "^8.0.9",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
-        "postcss-nested": "5.0.6",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-nested": "6.0.0",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
-        "resolve": "^1.22.0"
+        "resolve": "^1.22.1",
+        "sucrase": "^3.29.0"
       },
       "dependencies": {
         "color-name": {
@@ -54311,6 +54455,11 @@
             "is-glob": "^4.0.3"
           }
         },
+        "lilconfig": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+          "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="
+        },
         "postcss-import": {
           "version": "14.1.0",
           "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
@@ -54319,6 +54468,15 @@
             "postcss-value-parser": "^4.0.0",
             "read-cache": "^1.0.0",
             "resolve": "^1.1.7"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.11",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+          "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
           }
         },
         "quick-lru": {
@@ -54432,6 +54590,22 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
+    "thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
     "throat": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
@@ -54533,6 +54707,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
+    },
+    "ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "ts-invariant": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@apollo/client": "^3.5.10",
     "@code-hike/mdx": "^0.5.1-next.0",
     "@nrwl/next": "13.8.5",
-    "@tailwindcss/typography": "^0.5.2",
+    "@tailwindcss/typography": "^0.5.9",
     "axios": "0.27.2",
     "clsx": "^1.2.1",
     "core-js": "^3.25.1",
@@ -91,7 +91,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "7.27.0",
     "eslint-plugin-react-hooks": "4.3.0",
-    "eslint-plugin-tailwindcss": "^3.5.0",
+    "eslint-plugin-tailwindcss": "^3.11.0",
     "husky": "^8.0.1",
     "jest": "27.2.3",
     "lint-staged": "^13.0.3",
@@ -104,7 +104,7 @@
     "stylelint": "^14.3.0",
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-standard": "^24.0.0",
-    "tailwindcss": "^3.0.23",
+    "tailwindcss": "^3.3.1",
     "ts-jest": "27.1.3",
     "typescript": "~4.5.2"
   }


### PR DESCRIPTION
This PR upgrades Tailwind. Procedure was: 

1. Run `npm outdated`
2. Identify the packages with "tailwind" in the name. There were three.
3. Update the version strings in `package.json` to latest
4. Run `npm install` to update `package-lock.json` 

I also included a change to the Nebari Services page, showing why I wanted to upgrade Tailwind. The [`list-image-[url]` utility](https://tailwindcss.com/docs/list-style-image) was not working for me with our older version of Tailwind. With the newer version, it works.

When committing my changes, the new version of the eslint plugin updated the all of the files. There was a change in how class names are sorted by the linter. That's why this PR touches a lot of files. This shouldn't change anything user-facing. It's just trying to make the order consistent for Tailwind class names. One thing I like about this is that it puts all of the breakpoint-modified class names, such as `sm:` and `xl:`, at the end of the list.