### PR TITLE
Fix form prepopulate bug

### DIFF
--- a/apps/consulting/pages/nebari-services.tsx
+++ b/apps/consulting/pages/nebari-services.tsx
@@ -10,6 +10,7 @@ import 'swiper/css/bundle';
 import 'swiper/css/navigation';
 
 import { ISlugParams, DomainVariant } from '@quansight/shared/types';
+import { FormSessionStorageKeys } from '@quansight/shared/ui-components';
 import { Layout, SEO, Footer, Header } from '@quansight/shared/ui-components';
 
 import { PageItem } from '../api/types/basic';
@@ -22,27 +23,10 @@ import morningstarLogo from '../public/nebari-services/morningstar-logo.png';
 import nebariLogoWhite from '../public/nebari-services/nebari-logo-white.svg';
 import { TContainerProps } from '../types/containerProps';
 
-// This is kinda hacky. It runs a loop for up to 8 seconds checking every 400 ms
-// for the contact form. If it finds the contact form, it fills in the message
-// field.
-const prefillContactFormMessage = function (msg) {
-  let count = 20;
-  const intervalId = setInterval(() => {
-    if (!count--) {
-      clearInterval(intervalId);
-    }
-    const messageField: HTMLTextAreaElement | void = document.querySelector(
-      '#bookacallform [name=message]',
-    ) as HTMLTextAreaElement;
-    if (!messageField) {
-      return;
-    }
-    clearInterval(intervalId);
-    // Fill in the message field only if it hasn't already been filled in.
-    if (!messageField.value) {
-      messageField.value = msg;
-    }
-  }, 400);
+// Set a session storage value that can be read by the contact form to
+// prepopulate the message field.
+const prefillContactFormMessage = function (msg: string): void {
+  sessionStorage.setItem(FormSessionStorageKeys.Message, msg);
 };
 
 /* eslint-disable jsx-a11y/anchor-is-valid */

--- a/libs/shared/ui-components/src/Form/Form.tsx
+++ b/libs/shared/ui-components/src/Form/Form.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useState, useEffect } from 'react';
 
 import clsx from 'clsx';
 import { useForm } from 'react-hook-form';
@@ -18,7 +18,7 @@ import { FormError } from './FormError';
 import { FormHeader } from './FormHeader';
 import { FormImage } from './FormImage';
 import { FormSuccess } from './FormSuccess';
-import { FormStates, TFormProps } from './types';
+import { FormStates, TFormProps, FormSessionStorageKeys } from './types';
 import { getFormHeader, getTrackingParams } from './utils';
 
 export const backgroundStyles = `
@@ -32,8 +32,20 @@ export const Form: FC<TFormProps> = (props) => {
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors, isValid },
-  } = useForm<FormValues>({ mode: 'onChange' });
+  } = useForm<FormValues>({ mode: 'onSubmit' });
+
+  // Check session storage for form prepopulate values.
+  useEffect(() => {
+    // Other pages on the website can prepopulate the form message field by
+    // setting a session storage value before the form loads.
+    const message = sessionStorage.getItem(FormSessionStorageKeys.Message);
+    if (message) {
+      sessionStorage.removeItem(FormSessionStorageKeys.Message);
+      setValue('message', message);
+    }
+  }, [setValue]);
 
   const checkErrors = (): void => {
     if (!isValid) setFormStatus(FormStates.Errors);

--- a/libs/shared/ui-components/src/Form/Form.tsx
+++ b/libs/shared/ui-components/src/Form/Form.tsx
@@ -34,18 +34,22 @@ export const Form: FC<TFormProps> = (props) => {
     handleSubmit,
     setValue,
     formState: { errors, isValid },
-  } = useForm<FormValues>({ mode: 'onSubmit' });
+  } = useForm<FormValues>({ mode: 'onChange' });
 
   // Check session storage for form prepopulate values.
-  useEffect(() => {
-    // Other pages on the website can prepopulate the form message field by
-    // setting a session storage value before the form loads.
-    const message = sessionStorage.getItem(FormSessionStorageKeys.Message);
-    if (message) {
-      sessionStorage.removeItem(FormSessionStorageKeys.Message);
-      setValue('message', message);
-    }
-  }, [setValue]);
+  useEffect(
+    () => {
+      // Other pages on the website can prepopulate the form message field by
+      // setting a session storage value before the form loads.
+      const message = sessionStorage.getItem(FormSessionStorageKeys.Message);
+      if (message) {
+        sessionStorage.removeItem(FormSessionStorageKeys.Message);
+        setValue('message', message);
+      }
+    },
+    // eslint-disable-next-line
+    [], // Run effect only once, when the component mounts
+  );
 
   const checkErrors = (): void => {
     if (!isValid) setFormStatus(FormStates.Errors);

--- a/libs/shared/ui-components/src/Form/types.ts
+++ b/libs/shared/ui-components/src/Form/types.ts
@@ -7,6 +7,10 @@ export enum FormStates {
   Default = 'default',
 }
 
+export enum FormSessionStorageKeys {
+  Message = '#bookacallform [name=message]',
+}
+
 export type TFormHeaderProps = {
   title: string;
 };


### PR DESCRIPTION
The form library we use makes it difficult (impossible?) to programmatically change the value of a form field from outside the component and have the form pass validation.

So this PR moves that field prepopulation logic into the Form component and uses session storage as the place to get a prepopulate value from the outside.