### PR TITLE
Fetch annual report PDF instead of redirecting

### DIFF
--- a/apps/labs/pages/api/annual-report.pdf.ts
+++ b/apps/labs/pages/api/annual-report.pdf.ts
@@ -5,13 +5,6 @@ export const config = {
 };
 
 export default async function handler(req: NextRequest) {
-  // TODO - remove after checking the logs on Vercel
-  console.log(`
-  req.url ${req.url}
-  req.referer ${req.headers.get('referer')}
-  req.ip ${req.ip}
-  user-agent ${req.headers.get('user-agent')}
-  `);
   // The shape of this fetch comes from the Plausible docs:
   // https://plausible.io/docs/events-api
   await fetch('https://plausible.io/api/event', {
@@ -32,13 +25,9 @@ export default async function handler(req: NextRequest) {
       referrer: req.headers.get('referer'),
     }),
   });
-  // A few reasons to use 302 vs 301:
-  // - Ensures that this handler gets called every time that somebody clicks the
-  //   tracking URL for the PDF even if they've clicked it before.
-  // - It signals to search engines and other tech that we do not consider the
-  //   CDN URL for the annual report to be the canonical URL for this resource.
-  return Response.redirect(
+  // Returning fetch comes from Next.js docs:
+  // https://nextjs.org/docs/api-routes/edge-api-routes#forwarding-headers
+  return fetch(
     'https://a.storyblok.com/f/152463/x/20372ca74f/quansight-labs-annual-report-2022.pdf',
-    302,
   );
 }


### PR DESCRIPTION
This PR is a reversal of a decision I made in #645 ([long discussion](https://github.com/Quansight/Quansight-website/pull/645#discussion_r1093753223)).

This PR causes Next.js to pipe the Annual Report PDF from Storyblok through the URL https://labs.quansight.org/annual-reports/quansight-labs-annual-report-2022.pdf, rather than redirecting that URL to https://a.storyblok.com/f/152463/x/20372ca74f/quansight-labs-annual-report-2022.pdf.

Some weeks ago, Tania showed me a document (maybe it was for SciPy?) that was being made for print that had the Storyblok URL to the PDF, and it made me realize that the experience of being able to copy the URL from the browser and share that URL with others is fundamental. If we want accurate stats and we want people to be seeing and sharing the `labs.quansight.org` URL and not the Storyblok CDN URL, then we need to do it this way, and should have been doing it this way all along.

I highly doubt that this will be a problem for our Vercel usage, but I'll keep an eye out just in case.