### PR TITLE
Fix authors field in Array API in scikit-learn blog post

### DIFF
--- a/apps/labs/posts/array-api-support-scikit-learn.md
+++ b/apps/labs/posts/array-api-support-scikit-learn.md
@@ -1,7 +1,7 @@
 ---
 title: 'Array API Support in scikit-learn'
 published: September 19, 2023
-author: [thomas-j-fan]
+authors: [thomas-j-fan]
 description: 'In this blog post, we share how scikit-learn enabled support for the Array API Standard.'
 category: [Array API]
 featuredImage:

--- a/apps/labs/posts/array-api-support-scikit-learn.md
+++ b/apps/labs/posts/array-api-support-scikit-learn.md
@@ -1,7 +1,7 @@
 ---
 title: 'Array API Support in scikit-learn'
 published: September 19, 2023
-author: thomas-j-fan
+author: [thomas-j-fan]
 description: 'In this blog post, we share how scikit-learn enabled support for the Array API Standard.'
 category: [Array API]
 featuredImage:


### PR DESCRIPTION
Fix the format for author metadata in the Array API in scikit-learn blog post, which is causing the [Vercel deployment to fail](https://github.com/Quansight/Quansight-website/pull/771).

xref: #765, where we added the blog post