### PR TITLE
Update content CHANGELOG with team changes

### DIFF
--- a/apps/labs/CHANGELOG.md
+++ b/apps/labs/CHANGELOG.md
@@ -3,7 +3,7 @@ October 17, 2023
 Via Storyblok
 
 - Remove Thomas Fan, Mars Lee, and Pamphile Roy from the team page (switch Role from `team` to `author`)
-- Added Mateusz Sokół (switch Role from `author` to `team`) and Isuru Fernandoto (newly added) the team page
+- Added Mateusz Sokół (switch Role from `author` to `team`) and Isuru Fernandoto (newly added) to the team page
   
 
 May 27, 2023

--- a/apps/labs/CHANGELOG.md
+++ b/apps/labs/CHANGELOG.md
@@ -2,8 +2,9 @@ October 17, 2023
 
 Via Storyblok
 
-- Remove Thomas Fan and Pamphile Roy from the team page
-  (switch Role from `team` to `author`)
+- Remove Thomas Fan, Mars Lee, and Pamphile Roy from the team page (switch Role from `team` to `author`)
+- Added Mateusz Sokół (switch Role from `author` to `team`) and Isuru Fernandoto (newly added) the team page
+  
 
 May 27, 2023
 

--- a/apps/labs/CHANGELOG.md
+++ b/apps/labs/CHANGELOG.md
@@ -3,6 +3,7 @@ October 17, 2023
 Via Storyblok
 
 - Remove Thomas Fan and Pamphile Roy from the team page
+  (switch Role from `team` to `author`)
 
 May 27, 2023
 

--- a/apps/labs/CHANGELOG.md
+++ b/apps/labs/CHANGELOG.md
@@ -1,3 +1,9 @@
+October 17, 2023
+
+Via Storyblok
+
+- Remove Thomas Fan and Pamphile Roy from the team page
+
 May 27, 2023
 
 Via Storyblok


### PR DESCRIPTION
Removed Thomas Fan and Pamphile Roy from Team page display by changing their Storyblok Roles from `team` to `author`.