### PR TITLE
[MAINT] remove CuPy as a separate category on the Labs blog

### DIFF
--- a/apps/labs/posts/categories.json
+++ b/apps/labs/posts/categories.json
@@ -3,7 +3,6 @@
   "Array API",
   "Beyond PyData",
   "Community",
-  "CuPy",
   "Developer workflows",
   "Funding",
   "GPU",

--- a/apps/labs/posts/cupy-czi-grant-year1.md
+++ b/apps/labs/posts/cupy-czi-grant-year1.md
@@ -3,7 +3,7 @@ title: 'Improving the interpolation and signal processing capabilities of CuPy'
 published: November 23, 2023
 authors: [edgar-margffoy]
 description: 'We are excited to spread the news about the improvements that have been taking place in CuPy, where 18 interpolation and more than 100 signal processing parallel GPU APIs are now available as part of a EOSS4 CZI grant.'
-category: [GPU, PyData Ecosystem, CuPy]
+category: [GPU, PyData Ecosystem]
 featuredImage:
   src: /posts/cupy-czi-grant-year1/cupy_logo_1000px.png
   alt: 'The logo of the CuPy project. It describes a cube of three colors that is being built by other squares that come from each face'


### PR DESCRIPTION
This is a follow-up to gh-802