### PR TITLE
Switch all code blocks to use valid Code Hike languages

### DIFF
--- a/apps/consulting/posts/review-functorch-contribution.md
+++ b/apps/consulting/posts/review-functorch-contribution.md
@@ -26,6 +26,7 @@ calculating per-sample gradients becomes the straightforward application of
 Here are a few of the tasks we had the opportunity to tackle:
 
 ## Adding Batching Rules for `vmap`
+
 `vmap` is a transformation that accepts a function that operates on non-batched
 tensors and returns a new function that operates on batched tensors.
 When processing a batched input, an additional
@@ -36,6 +37,7 @@ operation efficiently by pushing the `for` loop into the PyTorch operations,
 allowing the batches to run in parallel.
 
 Consider the following example:
+
 ```python
 import torch
 
@@ -81,9 +83,10 @@ and other simpler composite operators. If we implement batching rules for every
 primitive operator, we automatically get the batching rules for composite operators.
 
 There are two ways to add batching support for an operator:
-* Manually write the batching rule. See for example the [batching rule for torch.dot](https://github.com/pytorch/pytorch/blob/b30ee35a6f141d3247a24fd09f96ea50a7e2b3c7/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp#L25-L34)
-* Decompose operators using other operators for which we already have a
-batching rule. See for example the [batching rule for torch.vdot](https://github.com/pytorch/pytorch/blob/b30ee35a6f141d3247a24fd09f96ea50a7e2b3c7/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp#L35-L37)
+
+- Manually write the batching rule. See for example the [batching rule for torch.dot](https://github.com/pytorch/pytorch/blob/b30ee35a6f141d3247a24fd09f96ea50a7e2b3c7/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp#L25-L34)
+- Decompose operators using other operators for which we already have a
+  batching rule. See for example the [batching rule for torch.vdot](https://github.com/pytorch/pytorch/blob/b30ee35a6f141d3247a24fd09f96ea50a7e2b3c7/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp#L35-L37)
 
 ## Composite Compliance
 
@@ -208,7 +211,7 @@ generate specialized code. In this case, it has fused `sin` and `square` to run
 within the same `for`-loop. This allows the generated program to do more compute
 per read/write effectively improving the memory bandwidth utilization.
 
-```c++
+```cpp
 extern "C" void kernel(const float* in_ptr0, float* out_ptr0) {
   for (long i0 = 0L; i0 < 16L; i0 += 8L) {
     auto tmp0 = at::vec::Vectorized<float>::loadu(in_ptr0 + i0);
@@ -264,7 +267,7 @@ successfully trace through this program in one graph.
 class GraphModule(torch.nn.Module):
     def forward(self, L_x_ : torch.Tensor):
         l_x_ = L_x_
-        
+
         # File: torch/_functorch/apis.py:363, code:
         # return eager_transforms.grad_impl(func, argnums, has_aux, args, kwargs)
         grad_body_0 = self.grad_body_0
@@ -272,7 +275,7 @@ class GraphModule(torch.nn.Module):
         call = grad_proxy.__call__(l_x_);  grad_proxy = l_x_ = None
         contiguous = call.contiguous();  call = None
         return (contiguous,)
-        
+
     class GraphModule(torch.nn.Module):
         def forward(self, l_x_):
             # No stacktrace found for following nodes
@@ -317,6 +320,7 @@ minimal limitations, providing a more comprehensive compilation support for `tor
 transforms
 
 ## Closing Remarks
+
 This project was yet another instance of the tight collaboration between Quansight
 and Meta within PyTorch. In particular, we would like to thank Richard Zou and
 Horace He, the `torch.func` creators, for all the design discussions and

--- a/apps/labs/posts/cxx-numba-interoperability.md
+++ b/apps/labs/posts/cxx-numba-interoperability.md
@@ -147,7 +147,7 @@ optional arguments:
 Next, let us consider the following C++ header and source file that we
 will use as a model of a C++ library:
 
-```c++
+```cpp
 /* File: foo.hpp */
 #include <iostream>
 int foo(int a);
@@ -202,7 +202,7 @@ Notice that the generated [cxx2py_libfoo.cpp](/posts/cxx-numba-interoperability/
 contains light-weight C functions for returning the addresses of C++
 functions:
 
-```c++
+```cpp
 #include <memory>
 #include <cstdint>
 #include "foo.hpp"

--- a/apps/labs/posts/making-gpus-accessible-to-pydata-ecosystem-via-array-api.md
+++ b/apps/labs/posts/making-gpus-accessible-to-pydata-ecosystem-via-array-api.md
@@ -388,7 +388,7 @@ don't match (e.g., `concat` in the standard instead of `np.concatenate`).
 
 Here is an example of a naming inconsistency between NumPy and the Array API standard:
 
-```ipython
+```py
 
 In [1]: import numpy as np
 In [2]: import numpy.array_api as npx
@@ -404,7 +404,7 @@ Out[4]: <function numpy.array_api._manipulation_functions.concat...>
 
 And here is an example of a behavioral inconsistency for an indexing operation:
 
-```ipython
+```py
 In [1]: import numpy as np
 In [2]: import numpy.array_api as npx
 

--- a/apps/labs/posts/quansight-labs-work-update-for-september-2019.md
+++ b/apps/labs/posts/quansight-labs-work-update-for-september-2019.md
@@ -110,7 +110,7 @@ you will be able to enable it by passing `boundscheck=True` to `@njit`, or by
 setting the `NUMBA_BOUNDSCHECK=1` environment variable. This will make it
 easier to detect out of bounds issues like the one above. It will work like
 
-```pycon
+```py
 >>> @njit(boundscheck=True)
 .def outtabounds(x):
 .    A = 0
@@ -166,8 +166,7 @@ Some reasons why `import *` is bad:
   level, `import *` will import every public (doesn't start with an
   underscore) name defined in the module file. This can often include things
   like standard library imports or loop variables defined at the top-level of
-  the file. For imports from modules (from `__init__.py`), `from module import
-  *` will include every submodule defined in that module. Using `__all__` in
+  the file. For imports from modules (from `__init__.py`), `from module import *` will include every submodule defined in that module. Using `__all__` in
   modules and `__init__.py` files is also good practice, as these things are
   also often confusing even for interactive use where `import *` is
   acceptable.
@@ -309,7 +308,6 @@ With the new [sphinx-math-dollar](https://www.sympy.org/sphinx-math-dollar/)
 Sphinx extension, this is now possible. Writing `$\nu$` produces $\nu$, and
 the above docstring can now be written as
 
-
 ```py
 class besselj(BesselBase):
     """
@@ -334,8 +332,7 @@ class besselj(BesselBase):
         J_{-n}(z) = (-1)^n J_n(z).
 ```
 
-We also plan to add support for `$$double dollars$$` for display math so that `..
-math ::` is no longer needed either .
+We also plan to add support for `$$double dollars$$` for display math so that `.. math ::` is no longer needed either .
 
 For end users, the documentation on [docs.sympy.org](https://docs.sympy.org)
 will continue to render exactly the same, but for developers, it is much

--- a/apps/labs/posts/sympy-documentation.md
+++ b/apps/labs/posts/sympy-documentation.md
@@ -228,7 +228,7 @@ before being removed.
 Two - a new `SymPyDeprecationWarning` class for deprecation warnings, which
 gives much more user friendly error messages. For example
 
-```python-console
+```py
 >>> import sympy.core.compatibility
 <stdin>:1: SymPyDeprecationWarning:
 
@@ -282,7 +282,7 @@ class log(Function):
         return 1/self.args[0]
 ```
 
-```python-console
+```py
 >>> x = sympy.Symbol('x')
 >>> log(1)
 0
@@ -307,7 +307,7 @@ goes over some ways to avoid these pitfalls.
 For example, one pitfall that many new SymPy users run into is using strings
 as inputs to SymPy functions, like
 
-```python-console
+```py
 >>> from sympy import expand
 >>> expand("(x**2 + x)/x")
 x + 1
@@ -316,7 +316,7 @@ x + 1
 It's much better to define symbolic variables and create expressions directly,
 like
 
-```python-console
+```py
 >>> from sympy import symbols
 >>> x = symbols('x')
 >>> expand((x**2 + x)/x)

--- a/apps/labs/posts/whats-new-in-sympy-14.md
+++ b/apps/labs/posts/whats-new-in-sympy-14.md
@@ -82,7 +82,7 @@ If you want the string form of an expression for copy-pasting, you can use
 
 Simplification of relational and piecewise expressions has been improved:
 
-```pycon
+```py
 >>> x, y, z, w = symbols('x y z w')
 >>> init_printing()
 >>> expr = And(Eq(x,y), x >= y, w < y, y >= z, z < y)
@@ -92,7 +92,7 @@ x = y ∧ x ≥ y ∧ y ≥ z ∧ w < y ∧ z < y
 x = y ∧ y > Max(w, z)
 ```
 
-```pycon
+```py
 >>> expr = Piecewise((x*y, And(x >= y, Eq(y, 0))), (x - 1, Eq(x, 1)), (0, True))
 >>> expr
 ⎧ x⋅y   for y = 0 ∧ x ≥ y
@@ -109,7 +109,7 @@ x = y ∧ y > Max(w, z)
 The MathML presentation printer has been greatly improved, putting it on par
 with the existing Unicode and LaTeX pretty printers.
 
-```pycon
+```py
 >>> mathml(Integral(exp(-x**2), (x, -oo, oo)), 'presentation')
 <mrow><msubsup><mo>&#x222B;</mo><mrow><mo>-</mo><mi>&#x221E;</mi></mrow><mi>&#x221E;</mi></msubsup><msup><mi>&ExponentialE;</mi><mrow><mo>-</mo><msup><mi>x</mi><mn>2</mn></msup></mrow></msup><mo>&dd;</mo><mi>x</mi></mrow>
 ```
@@ -128,7 +128,7 @@ presentation form for `Integral(exp(-x**2), (x, -oo, oo))` below:
 
 Several improvements have been made to the solvers.
 
-```pycon
+```py
 >>> eq = Eq((x**2 - 7*x + 11)**(x**2 - 13*x + 42), 1)
 >>> eq
                 2
@@ -145,7 +145,7 @@ been added.
 `'nth_algebraic'` solves ODEs using `solve` by inverting the derivatives
 algebraically:
 
-```pycon
+```py
 >>> f = Function('f')
 >>> eq = Eq(f(x) * (f(x).diff(x)**2 - 1), 0)
 >>> eq
@@ -160,7 +160,7 @@ algebraically:
 `'nth_order_reducible'` solves ODEs that only involve derivatives of `f(x)`,
 via the substitution $g(x)=f^\{(n)\}(x)$.
 
-```pycon
+```py
 >>> eq = Eq(Derivative(f(x), (x, 2)) + x*Derivative(f(x), x), x)
 >>> eq
                2

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.5.10",
-        "@code-hike/mdx": "^0.5.1-next.0",
+        "@code-hike/mdx": "^0.9.0",
         "@nrwl/next": "13.8.5",
         "@tailwindcss/typography": "^0.5.2",
         "axios": "0.27.2",
@@ -2126,19 +2126,21 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@code-hike/lighter": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@code-hike/lighter/-/lighter-0.7.0.tgz",
+      "integrity": "sha512-64O07rIORKQLB+5T/GKAmKcD9sC0N9yHFJXa0Hs+0Aee1G+I4bSXxTccuDFP6c/G/3h5Pk7yv7PoX9/SpzaeiQ==",
+      "funding": {
+        "url": "https://github.com/code-hike/lighter?sponsor=1"
+      }
+    },
     "node_modules/@code-hike/mdx": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@code-hike/mdx/-/mdx-0.5.2.tgz",
-      "integrity": "sha512-VAOdHCFDkrRZygzw9LGEWoFKvmg7CXD9q8I4ugOcFGPYA4JnK4imuqoTEL7ALGOHIdUihLt0Mnf7t+Z+gcwGLg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@code-hike/mdx/-/mdx-0.9.0.tgz",
+      "integrity": "sha512-0wg68ZCjVWAkWT4gBUZJ8Mwktjen/XeWyqBQCrhA2IZSbZZnMYsEI6JJEFb/nZoNI3comB3JdxPLykZRq3qT2A==",
       "dependencies": {
-        "hast-util-to-estree": "^1.4.0",
-        "is-plain-obj": "^3.0.0",
-        "node-fetch": "^2.0.0",
-        "remark-rehype": "^8.1.0",
-        "shiki": "^0.10.1",
-        "unified": "^9.2.2",
-        "unist-util-visit": "^2.0.0",
-        "unist-util-visit-parents": "^3.0.0"
+        "@code-hike/lighter": "0.7.0",
+        "node-fetch": "^2.0.0"
       },
       "funding": {
         "type": "github",
@@ -8969,15 +8971,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/bail": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -9912,15 +9905,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/comma-separated-tokens": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -12491,15 +12475,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estree-util-attach-comments": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-1.0.0.tgz",
-      "integrity": "sha512-sL7dTwFGqzelPlB56lRZY1CC/yDxCe365WQpxNd49ispL40Yv8Tv4SmteGbvZeFwShOOVKfMlo4jrVvwoaMosA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/estree-util-build-jsx": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-2.1.0.tgz",
@@ -12527,15 +12502,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.1.tgz",
       "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g=="
-    },
-    "node_modules/estree-util-is-identifier-name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-1.1.0.tgz",
-      "integrity": "sha512-OVJZ3fGGt9By77Ix9NhaRbzfbDV/2rx9EP7YIDJTmsZSEc5kYn2vWcNccYyahJL2uAQZK2a5Or2i0wtIKTPoRQ==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/estree-util-visit": {
       "version": "1.1.0",
@@ -14093,26 +14059,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-to-estree": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-1.4.0.tgz",
-      "integrity": "sha512-CiOAIESUKkSOcYbvTth9+yM28z5ArpsYqxWc7LWJxOx975WRUBDjvVuuzZR2o09BNlkf7bp8G2GlOHepBRKJ8Q==",
-      "dependencies": {
-        "comma-separated-tokens": "^1.0.0",
-        "estree-util-attach-comments": "^1.0.0",
-        "estree-util-is-identifier-name": "^1.1.0",
-        "hast-util-whitespace": "^1.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0",
-        "style-to-object": "^0.3.0",
-        "unist-util-position": "^3.1.0",
-        "zwitch": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-2.0.0.tgz",
@@ -14120,15 +14066,6 @@
       "dependencies": {
         "@types/hast": "^2.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-whitespace": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
-      "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -19637,18 +19574,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/mdast-util-definitions": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz",
-      "integrity": "sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==",
-      "dependencies": {
-        "unist-util-visit": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.0.tgz",
@@ -19867,25 +19792,6 @@
         "@types/mdast": "^3.0.0",
         "mdast-util-from-markdown": "^1.0.0",
         "mdast-util-to-markdown": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-hast": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
-      "integrity": "sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "@types/unist": "^2.0.0",
-        "mdast-util-definitions": "^4.0.0",
-        "mdurl": "^1.0.0",
-        "unist-builder": "^2.0.0",
-        "unist-util-generated": "^1.0.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22997,18 +22903,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/property-information": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
-      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -23894,18 +23788,6 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-8.1.0.tgz",
-      "integrity": "sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==",
-      "dependencies": {
-        "mdast-util-to-hast": "^10.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -24921,15 +24803,6 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
-    "node_modules/space-separated-tokens": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -26134,15 +26007,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/trough": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
@@ -26665,71 +26529,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/unified": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
-      "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
-      "dependencies": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-buffer": "^2.0.0",
-        "is-plain-obj": "^2.0.0",
-        "trough": "^1.0.0",
-        "vfile": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unified/node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/unified/node_modules/unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "dependencies": {
-        "@types/unist": "^2.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unified/node_modules/vfile": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unified/node_modules/vfile-message": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/union": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
@@ -26739,42 +26538,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/unist-builder": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
-      "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-generated": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
-      "integrity": "sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-is": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-position": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
-      "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-position-from-estree": {
@@ -26844,33 +26607,6 @@
       "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
       "dependencies": {
         "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -27958,15 +27694,6 @@
       "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
       "dependencies": {
         "zen-observable": "0.8.15"
-      }
-    },
-    "node_modules/zwitch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
-      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.5.10",
-    "@code-hike/mdx": "^0.5.1-next.0",
+    "@code-hike/mdx": "^0.9.0",
     "@nrwl/next": "13.8.5",
     "@tailwindcss/typography": "^0.5.2",
     "axios": "0.27.2",


### PR DESCRIPTION
[Code Hike code block docs](https://codehike.org/docs/codeblocks)

- Code Hike does not differentiate between flavors of Python formatting. There is only `python` (or `py`)
- C++ is `cpp`

Not sure why we're getting errors for `c` and `rst`, as both of those are declared as supported.

<img width="400" src="https://github.com/Quansight/Quansight-website/assets/11325439/377d6bb2-0849-495c-a264-d5b402d95641">

Perhaps we need to update Code Hike?