### PR TITLE
[MAINT] Raise limit for warning about page size

### DIFF
--- a/apps/labs/next.config.js
+++ b/apps/labs/next.config.js
@@ -13,6 +13,10 @@ const nextConfig = {
   images: {
     domains: ['a.storyblok.com'],
   },
+  experimental: {
+    // Only warn about built pages at 1MB and above
+    largePageDataBytes: 1024 * 1024,
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
This PR would raise the limit for page size that triggers a warning during build.

The only effect here is to quiet the build log output. I don't think there's much we can do about the page sizes.

One reason not to do this is because the setting is still `experimental`, and may cause problems with builds later on.

I'm +0.5 to making this change, but would understand a decision not to.