### PR TITLE
Fix headings in blog posts

### DIFF
--- a/apps/labs/posts/better-interractive-jupyter-session-with-pyflyby.md
+++ b/apps/labs/posts/better-interractive-jupyter-session-with-pyflyby.md
@@ -30,8 +30,7 @@ project and an extension to IPython and
 [JupyterLab](https://github.com/deshaw/jupyterlab-pyflyby), that, among many
 things, automatically inserts imports and tidies Python files and notebooks.
 
-
-# What is pyflyby?
+## What is pyflyby?
 
 Pyflyby is a set of tools designed to improve interactive and non-interactive
 workflows in Python. Pyflyby provides a number of utilities and extensions aimed
@@ -65,7 +64,6 @@ the `py` executable replacing python.
 With the [jupyterlab-pyflyby](https://github.com/deshaw/jupyterlab-pyflyby) extension, imports will be executed and inserted in
 the first cell of one's notebook:
 
-
 ![Fresh Jupyter session with two cells: the first imports Matplotlib, and the
 second plots using both Matplotlib and NumPy. Upon execution, jupyterlab-pyflyby
 automatically adds the missing NumPy import in the first cell, and then
@@ -82,7 +80,6 @@ format imports in Python files. This is similar to tools such as
 [black](https://pypi.org/project/black/) and
 [isort](https://pypi.org/project/isort/), but with different styling options and
 with the ability to infer missing imports.
-
 
 `tidy-import` includes the imports to pandas and matplotlib, as in the example
 below, and queries whether to update the file:
@@ -114,11 +111,10 @@ IPython or to execute commands quickly from the developer's shell without the
 need for imports. It supports a range of syntax options, allowing for quick
 calculation and graph plotting.
 
- - Without any parameters, `py` will start IPython with the pyflyby extension
-   activated.
- - With space-separated arguments, `py` will attempt to interpret each argument
-   as a Python function call with the right imports:
-
+- Without any parameters, `py` will start IPython with the pyflyby extension
+  activated.
+- With space-separated arguments, `py` will attempt to interpret each argument
+  as a Python function call with the right imports:
 
 ```bash
 $ py np.random.normal 0 1
@@ -139,12 +135,12 @@ $ py 'plot(scipy.stats.norm.pdf(linspace(-5, 5), 0, 1))'
 ```
 
 ![Bash shell where the py command is passed a string argument, which is code
-that renders a Matplotlib plot using methods that were not imported. The plot 
+that renders a Matplotlib plot using methods that were not imported. The plot
 successfully renders. The Python code used is printed, which contains the
 automatically inferred imports and ends with the passed code.](/posts/better-interractive-jupyter-session-with-pyflyby/py-exec-matplotlib.png)
 
 `find-import` , another utility available in pyflyby, can be deployed to find a
-particular function across many libraries by returning the relevant import.  For
+particular function across many libraries by returning the relevant import. For
 example:
 
 ```bash
@@ -152,24 +148,23 @@ $ find-import norm
 from scipy.stats.distributions import norm
 ```
 
-# Notes on pyflyby codebase
+## Notes on pyflyby codebase
 
 The [Pyflyby codebase](https://github.com/deshaw/pyflyby) provides a window into
 advanced data structures and programming paradigms. Its use of modules and
 programming concepts is unusual relative to those found in more classical data
 science-focused libraries. For example:
 
- - Pyflyby will conduct non-trivial manipulation of the Python Abstract Syntax
-   Tree (AST), which represents code written in tree form. Pyflyby uses AST to
-   find and insert missing imports, and it does so even as AST's exact
-   representation changes with almost every minor release.
+- Pyflyby will conduct non-trivial manipulation of the Python Abstract Syntax
+  Tree (AST), which represents code written in tree form. Pyflyby uses AST to
+  find and insert missing imports, and it does so even as AST's exact
+  representation changes with almost every minor release.
 
- - Pyflyby demonstrates the use of  [Aspect-Oriented
-   programming](https://en.wikipedia.org/wiki/Aspect-oriented_programming),
-   which highlights the flexibility of the Python programming model.
+- Pyflyby demonstrates the use of [Aspect-Oriented
+  programming](https://en.wikipedia.org/wiki/Aspect-oriented_programming),
+  which highlights the flexibility of the Python programming model.
 
-
-# Conclusion
+## Conclusion
 
 Pyflyby's utilities are designed to improve developer efficiency and materially
 reduce the impact of interruption on productivity. Its value, however, is
@@ -177,7 +172,7 @@ broader than that. Pyflyby expands what one is capable of doing within the Pytho
 and has helped identify a number of limitations and bugs in Python and IPython
 over time.
 
-# How to get pyflyby
+## How to get pyflyby
 
 Pyflyby is available on [GitHub](https://github.com/deshaw/pyflyby) or, for
 terminal IPython users:
@@ -191,18 +186,7 @@ JupyterLab users can also install [the JupyterLab
 Extension](https://github.com/deshaw/jupyterlab-pyflyby), which is
 notebook-aware and enables even more features.
 
-
-# Acknowledgements
+## Acknowledgements
 
 Pyflyby was created by Karl Chen and is supported by the [D. E. Shaw
 group](https://www.deshaw.com/) in collaboration with [Quansight](https://www.quansight.com).
-
-
-
-
-
-
-
-
-
-

--- a/apps/labs/posts/but-what-are-traitlets.md
+++ b/apps/labs/posts/but-what-are-traitlets.md
@@ -19,11 +19,11 @@ hero:
 You have probably seen Traitlets in applications, you likely even use it. The package has nearly 5 million downloads
 on [conda-forge](https://anaconda.org/conda-forge/traitlets) alone.
 
-# But, what is Traitlets ?
+## But, what is Traitlets ?
 
 In this post we'll answer this question along with where Traitlets came from, its applications, and a bit of history.
 
-## `traitlets` 5.0
+### `traitlets` 5.0
 
 `traitlets` 5.0 has recently been released; 5 years after the earliest versions of
 `traitlets` 4.0. The latest and greatest 5.0 release brings
@@ -34,25 +34,25 @@ Traitlets is [a library](https://pypi.org/project/traitlets) that provides objec
 can expose individual configuration options in an intelligent way. They are used in almost all the Jupyter Projects.
 
 Traitlets began as a pure Python implementation of the Enthought [Traits](https://pypi.org/project/traits/) library.
-These libraries implement the object-oriented [trait pattern](https://en.wikipedia.org/wiki/Trait_(computer_programming)). Prior to 2015, `traitlets` was a part of the IPython (pre-jupyter) code base; then during ["The Big
+These libraries implement the object-oriented [trait pattern](<https://en.wikipedia.org/wiki/Trait_(computer_programming)>). Prior to 2015, `traitlets` was a part of the IPython (pre-jupyter) code base; then during ["The Big
 Split"](https://blog.jupyter.org/the-big-split-9d7b88a031a7) it was moved to their own reusable package.
 
-Both `traitlets` and `traits` addressed the challenge of using typed code in interactive Python [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop "read-eval-print-loop")s. They offer type checking, coercion and validation at run time.
+Both `traitlets` and `traits` addressed the challenge of using typed code in interactive Python [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop 'read-eval-print-loop')s. They offer type checking, coercion and validation at run time.
 
-### Traitlets for development
+#### Traitlets for development
 
 The general idea when developing with Traitlets is:
 
 1. The developer defines a class-level attribute,
 
 2. This class level attribute will automatically be converted into
-    *a property-like* element with *runtime type and value checking*, *configurability* and
-    *observable events and changes*.
+   _a property-like_ element with _runtime type and value checking_, _configurability_ and
+   _observable events and changes_.
 
 Traitlets minimizes boilerplate for Python applications. Traitlets maintains a uniform
 naming convention and helps your users configure their applications.
 
-## A Traitlets usage example
+### A Traitlets usage example
 
 We'll demonstrate the flexibility of Traitlets by configuring the `autocall`
 traitlet/option of IPython from the command line interface, configuration
@@ -87,7 +87,6 @@ either `0`,`1`, or `2`. Traitlets provides a number of utilities to decide
 whether assigning incorrect values should raise an exception; or coerce to one
 of the valid ones. Here a wrong assignment will fail:
 
-
 ```
 $ ipython --no-banner
 
@@ -101,7 +100,6 @@ In [3]: ip.autocall = 5
 TraitError: The 'autocall' trait of a TerminalInteractiveShell instance expected any of [0, 1, 2], not the int 5.
 ```
 
-
 While type – and value – checking at runtime is a nice feature, most of these
 options are usually user preferences. Traitlets provides a way to automatically
 create configuration files with help, as well as command line arguments
@@ -111,8 +109,7 @@ application on how to automatically generate configuration files, decide on
 the option name and document it. No need for the developer to spend time on
 deciding on a configuration parameter name.
 
-
-### A generated configuration file.
+#### A generated configuration file.
 
 On a brand new machine with IPython installed you will find the following in
 your default configuration file `~/.ipython/profile_default/ipython_config.py`,
@@ -171,7 +168,6 @@ to actually do the reformatting, the complete diff to add the options to the CLI
 configuration file, and [automatic generation](https://github.com/ipython/traitlets/blob/3293530b6943b9522ae570e7ca29b30709a43567/traitlets/config/sphinxdoc.py#L1-L33) of [the option documentation](https://ipython.readthedocs.io/en/7.18.0/config/options/terminal.html#configtrait-TerminalInteractiveShell.autoformatter) in Sphinx
 documentation is as follows:
 
-
 ```diff
 @IPython/terminal/interactiveshell.py:98
 Class TerminalInteractiveShell(InteractiveShell)
@@ -192,7 +188,7 @@ configuration options is decentralized and lives on the object being
 configured. And there is no differences between adding a configuration option
 in the configuration file or at the command line interface.
 
-# Configure what you do not yet know about
+## Configure what you do not yet know about
 
 In an application with few parameters and only a couple of plugins it might be
 relatively straightforward to provide options and CLI arguments; this becomes
@@ -241,10 +237,9 @@ Thus if you have an application or library with a number of plugins, and for
 which configurability can be thought of as tree-like similar to a class
 hierarchy, Traitlets can help you.
 
+## Other functionalities
 
-# Other functionalities
-
-## Observability
+### Observability
 
 Beyond the configurability part is observability; as we already had a great
 type system with hooks, and sometimes you may want to mutate configuration of
@@ -278,8 +273,7 @@ visualisations.
 This can be useful to glue together models, with parameters needing to be
 synchronized and models needing to react to changes.
 
-
-## Dynamic defaults
+### Dynamic defaults
 
 Traitlets supports [dynamic defaults](https://traitlets.readthedocs.io/en/stable/api.html#dynamic-default-values),
 i.e. your default values may depend on some context (OS, Python version).
@@ -287,8 +281,7 @@ i.e. your default values may depend on some context (OS, Python version).
 Configurations are by default Python scripts (but can be JSON), so user
 config files can be shared across machines and have dynamic values.
 
-
-## Context base configuration
+### Context base configuration
 
 Object configuration can also look at the creator of the object at instantiation
 time.
@@ -303,24 +296,24 @@ default values. This is for example used by [nbconvert](https://github.com/jupyt
 to decide which options to activate depending on whether you do `--to=pdf`,
 or `--to-html`
 
-## Flags and aliases
+### Flags and aliases
 
 Long flag names like `--InteractiveShell.debug=True` can be cumbersome to type.
 That is why traitlets provide aliases and flags, so that `ipython --debug` will
 set `debug=True` to enable logging on all classes supporting it while still
 allowing you to tweak the login level used on a per-class basis.
 
-# Limitations
+## Limitations
 
 Of course all this power doesn't come completely for free:
 
- - Your class and attribute names become part of your API
- - As configuration is loaded/read before any potential plugins are loaded, it is
-   impossible to definitively detect typos or invalid configuration options.
- - Traitlets relies heavily on metaclasses, so it can add a construction cost to
-   your objects and can be hard to debug.
+- Your class and attribute names become part of your API
+- As configuration is loaded/read before any potential plugins are loaded, it is
+  impossible to definitively detect typos or invalid configuration options.
+- Traitlets relies heavily on metaclasses, so it can add a construction cost to
+  your objects and can be hard to debug.
 
-# Conclusion
+## Conclusion
 
 This was a short introduction to Traitlets. I hope it made it a little clearer
 how the Jupyter configuration system works, and we are looking forward to see
@@ -334,18 +327,3 @@ If you want to learn more, see [this JupyterCon 2018
 talk](https://www.youtube.com/watch?v=_gYEVTaNuKU) and the [documentation](https://traitlets.readthedocs.io/).
 
 Try the new 5.x version and let us know if you have questions.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/apps/labs/posts/code-generator-and-nebari.md
+++ b/apps/labs/posts/code-generator-and-nebari.md
@@ -14,7 +14,7 @@ hero:
 
 To the readers, I am Aryan Gupta(@[guptaaryan16](https://github.com/guptaaryan16/)), an EE Junior at IIT Roorkee, and this summer, I had a chance to work on PyTorch-Ignite’s Code-Generator project, a tailor-made web application to help machine learning researchers and enthusiasts and also keeping in mind the growing Kaggle community.
 
-# The project itself
+## The project itself
 
 Let’s see the project itself. [Code-Generator](https://code-generator.pytorch-ignite.ai/) is a [Vue.js](https://vuejs.org/) application that streamlines the process of working on machine learning tasks. The app generates preconfigured code templates for tasks like vision classification, text classification, and other common themes in ML competitions.
 
@@ -24,7 +24,7 @@ This app was created with the great efforts of members of the PyTorch-Ignite com
 
 ![The Code-Generator App](/posts/code-generator-and-nebari/app.png)
 
-# The issues I worked on
+## The issues I worked on
 
 My tasks were primarily to work on features that could improve the reproducibility-related features of the templates. Also, I had to contribute to new features and libraries which can be best for experiments' configuration management. My contributions to the project were mainly three-fold, and are detailed below.
 
@@ -113,7 +113,7 @@ But it can be challenging to manage, and we also need to ensure we satisfy the `
 
 Some of the related PRs can be found here: [#283](https://github.com/pytorch-ignite/code-generator/pull/283) [#288](https://github.com/pytorch-ignite/code-generator/pull/288)
 
-# The way forward for the project
+## The way forward for the project
 
 The Code-Generator project seems to be moving forward at a great pace and is expected to have many more additions in the future. Starting and maintaining a new project is challenging in open source and can have a very high risk/reward ratio. Still, good communities try their best to make and maintain projects that can be helpful for the maximum number of people and reduce the friction for new people entering the community. Here are some of the issues I suggest and may work on in the future.
 
@@ -131,7 +131,7 @@ We will add more templates and feature options in the future to the project. Tem
 
 P.S. If you feel excited about the project, please feel free to suggest more changes and contribute to the project.
 
-# Some lessons I learnt along the way
+## Some lessons I learnt along the way
 
 This internship experience increased my confidence in maintaining an open-source codebase and understanding how to test functions and debug changes. It also helped me understand the value of real-life design decisions and CI and how they can significantly influence the project for the good or the bad. Some of the best practices I learned in the open-source projects are listed below.
 
@@ -144,7 +144,7 @@ When we try to write new code or change the existing files, we often try to do i
 While making a pull request(PR) seems very exciting on a project, you should know what and how much you want to accomplish in one pull request. Sometimes, we can make too many functional changes in one pull request, making testing and removing all the bugs difficult. This issue was evident in my time as an intern as some of my PRs were terribly formatted, and this led to me completely rebasing them and making 4-5 more PRs to the main project to remove many bugs in those changes. This was painful for me and my mentor, but I thank him for helping me with great suggestions and reviews.
 Also, this experience increased my learning and helped me improve the quality of my pull requests. So don’t be afraid to make mistakes; learn from them and make your way in this incredible world of OSS!
 
-# Acknowledgements
+## Acknowledgements
 
 In this section, I would like to thank my mentor, @[vfdev-5](https://github.com/vfdev-5), and other members of the PyTorch-Ignite community for helping me in this internship. Also, I would like to thank the people at [Quansight-Labs](https://quansight.com/) for providing me with such a great opportunity, especially @[rgommers](https://github.com/rgommers), @[trallard](https://github.com/trallard), @[melissawm](https://github.com/melissawm), and others for their invaluable guidance and time during this internship.
 

--- a/apps/labs/posts/cxx-numba-interoperability.md
+++ b/apps/labs/posts/cxx-numba-interoperability.md
@@ -266,7 +266,7 @@ in foo(7)
 130
 ```
 
-# Summary
+## Summary
 
 In this post, we outlined a method of calling C++ library functions
 from Python with an emphasis on their usage from Numba compiled
@@ -275,12 +275,12 @@ functions with minimal overhead. While the provided tool
 with scalar inputs and return values, it can be easily extended to
 support other C++ features as well.
 
-# Acknowledgements
+## Acknowledgements
 
 I thank Breno Campos and Guilherme Leobas for discussions and for sharing
 their expertise on the [LLVM Project](https://www.llvm.org/).
 
-# Appendix: A list of Python/C/C++ connectivity tools
+## Appendix: A list of Python/C/C++ connectivity tools
 
 - [Boost.Python: C++ library with a IDL-like interface for binding C++ classes and functions to Python](https://www.boost.org/doc/libs/1_75_0/libs/python/doc/html/index.html)
 - [cffi: C Foreign Function Interface for Python](https://cffi.readthedocs.io/en/latest/)

--- a/apps/labs/posts/czi-eoss4-grants-at-quansight-labs.md
+++ b/apps/labs/posts/czi-eoss4-grants-at-quansight-labs.md
@@ -3,7 +3,14 @@ title: 'CZI EOSS4 Grants at Quansight Labs'
 published: August 31, 2021
 authors: [ralf-gommers]
 description: 'We are thrilled to announce that the team at Quansight Labs has been awarded five EOSS Cycle 4 grants to work on several projects within the PyData ecosystem. This post will introduce the successful grantees and their objectives for these two-year long grants.'
-category: [Access-centered, Developer workflows, Funding, OSS Experience, PyData Ecosystem]
+category:
+  [
+    Access-centered,
+    Developer workflows,
+    Funding,
+    OSS Experience,
+    PyData Ecosystem,
+  ]
 featuredImage:
   src: /posts/czi-eoss4-grants-at-quansight-labs/blog_feature_org.png
   alt: 'An illustration of a brown and a white hand coming towards each other to pass a business card with the logo of Quansight Labs'
@@ -21,11 +28,12 @@ CZI’s Essential Open Source Software for Science program supports software mai
 Today, we are thrilled to announce that the team at Quansight Labs [has been awarded](https://chanzuckerberg.com/newsroom/czi-awards-16-million-for-foundational-open-source-software-tools-essential-to-biomedicine/) five EOSS Cycle 4 grants to work on several projects within the PyData ecosystem. This post will introduce the successful grantees and their objectives for these two-year long grants.
 
 ## Maintenance & Extension of Scikit-learn: Machine Learning in Python
+
 **PI: Thomas Fan**
 
 This proposal aims to decrease the maintenance backlog of scikit-learn and increase responsiveness to issues and new pull-requests. The team expects that reducing the number of open issues and response and pull-request review timelines will increase community and contributor engagement in the long run.
 
-In addition to day-to-day maintenance, this grant will also enable the  scikit-learn team to focus on adding new features, such as:
+In addition to day-to-day maintenance, this grant will also enable the scikit-learn team to focus on adding new features, such as:
 
 - Column name consistency
 - `ColumnTransformer` outputting pandas DataFrames
@@ -39,6 +47,7 @@ As part of the project's commitment to Diversity, Equity and Inclusion, the team
 [CZI proposal page](https://chanzuckerberg.com/eoss/proposals/maintenance-extension-of-scikit-learn-machine-learning-in-python/)
 
 ## SymPy: Improving Foundational Open Source Symbolic Mathematics for Science
+
 **PIs: Aaron Meurer, Jason Moore, and Oscar Benjamin**
 
 This proposal focuses on [SymPy](https://www.sympy.org/) maintenance and improvements in three critical areas:
@@ -59,9 +68,10 @@ Lastly, Aaron Meurer will focus on improving the high-level documentation of Sym
 [CZI proposal page](https://chanzuckerberg.com/eoss/proposals/sympy-improving-foundational-open-source-symbolic-mathematics-for-science/)
 
 ## Advancing an inclusive culture in the scientific Python ecosystem
+
 **PI: Melissa Mendonça**
 
- This joint proposal from [NumPy](https://numpy.org/), [SciPy](https://scipy.org/), [Matplotlib](https://matplotlib.org/), and [Pandas](https://pandas.pydata.org/) was submitted as part of a supplemental program called [Essential Open Source Software Diversity & Inclusion](https://cziscience.medium.com/advancing-diversity-and-inclusion-in-scientific-open-source-eaabe6a5488b).
+This joint proposal from [NumPy](https://numpy.org/), [SciPy](https://scipy.org/), [Matplotlib](https://matplotlib.org/), and [Pandas](https://pandas.pydata.org/) was submitted as part of a supplemental program called [Essential Open Source Software Diversity & Inclusion](https://cziscience.medium.com/advancing-diversity-and-inclusion-in-scientific-open-source-eaabe6a5488b).
 Melissa Mendonça will lead this effort as the PI and include 1-2 maintainers of each project to help set priorities and guide the work, targeted towards Diversity, Equity and Inclusion (DEI).
 
 This grant will help create two Contributor Experience Lead positions, which will involve a mixture of technical and community work with a particular focus on DEI.
@@ -79,6 +89,7 @@ Another goal of this project is to align documentation across the involved proje
 [CZI proposal page](https://chanzuckerberg.com/eoss/proposals/advancing-an-inclusive-culture-in-the-scientific-python-ecosystem/)
 
 ## Inclusive and Accessible Scientific Computing in the Jupyter Ecosystem
+
 **PI: Tania Allard**
 
 A critical aspect of open-source Scientific Computing is to enable projects to be accessible to all users. This grant was awarded to Jupyter with Tania as PI and Isabela Presedo-Floyd and Tony Fast as other named Quansight Labs members on the proposal to address existing accessibility issues within the Jupyter Ecosystem.
@@ -94,6 +105,7 @@ By improving accessibility for everyone, the team aspires to broaden the Jupyter
 [CZI proposal page](https://chanzuckerberg.com/eoss/proposals/inclusive-and-accessible-scientific-computing-in-the-jupyter-ecosystem/)
 
 ## Papyri: Better documentation for the Scientific Ecosystem in Jupyter
+
 **PI: Matthias Bussonnier**
 
 This proposal focuses on a significant overhaul of the Jupyter and IPython interactive documentation framework with many features currently only available in hosted websites (inline graphs, search, navigation). Such an approach will provide a less distractive coding experience for Jupyter users while making documentation more accessible.
@@ -105,7 +117,6 @@ Therefore, through this grant, the team will make this implementation possible a
 
 [CZI proposal page](https://chanzuckerberg.com/eoss/proposals/papyri-better-documentation-for-the-scientific-ecosystem-in-jupyter/)
 
-# Join us
+## Join us
 
 All of the projects mentioned in this blogpost are open-source community-led projects across the PyData ecosystem. Thanks to the CZI funding, the Quansight Labs team will enable more contributions, but we welcome and encourage your help. If you have a particular interest in any of these projects or are interested in the work we do at Quansight and Quansight Labs, have a look at our [jobs posting](https://www.quansight.com/careers) (Most of our positions are Remote OK and worldwide) and feel free to contact us.
-

--- a/apps/labs/posts/dataframe-interop-pycon-lit-2024.md
+++ b/apps/labs/posts/dataframe-interop-pycon-lit-2024.md
@@ -12,8 +12,6 @@ hero:
   imageAlt: 'Narwhals logo'
 ---
 
-# DataFrame Interoperability
-
 I attended PyCon Lithuania 2024, and had a blast! I don't speak Lithuanian, and probably
 neither did half the attendees. But - so long as we all stuck to a simple and clear subset
 of the English language - we could all understand each other and exchange ideas. I actually
@@ -25,12 +23,14 @@ make mistakes. If you learn a bit of
 Spanish, you might think that "estoy embarazado" means "I'm embarrassed", but it actually
 means "I'm pregnant". Similarly, after learning a bit of pandas and Polars, you might
 expect
+
 ```python
 import pandas as pd
 import polars as pd
 
 print((3 in pd.Series([1,2,3])) == (3 in pl.Series([1,2,3])))
 ```
+
 to print `'True'` - but not so! pandas checks if `3` is in the index, whereas Polars checks
 if `3` is in the values.
 

--- a/apps/labs/posts/github-actions-benchmarks.md
+++ b/apps/labs/posts/github-actions-benchmarks.md
@@ -21,7 +21,7 @@ hero:
   does not happen and we can observe ratios between 0.6 and 1.5. This plot shows that while there
   is an observable y-spread, it is small enough to be considered sensitive to performance
   regressions of more than 50%.'
-  
+
 ---
 
 ![Reliability of benchmarks in GitHub Actions. This 2D plot shows a 16-day timeseries in the X axis.
@@ -45,7 +45,7 @@ Well, it turns out that there _is_ a sensible way to do it: **relative benchmark
 And we know it works because we have been collecting stability data points for several
 weeks.
 
-# Good benchmarking on shared resources?
+## Good benchmarking on shared resources?
 
 Speed-critical projects use benchmark suites to track performance over time and detect
 regressions from commit to commit. For these measurements to be useful, they need to
@@ -59,14 +59,14 @@ cloud resources normally used for CI tests. Ideally, GitHub Actions.
 Let's compare the requirements for good benchmarks and the features provided by CI services.
 That way we can understand how to work around some of the apparent limitations:
 
-| A good benchmark suite.| CI services.|
-| ------------------------- | -------------- |
-| runs on the same hardware every time | provide a different (standardized) machine for each run |
-| runs on dedicated hardware | run on shared resources |
-| runs on a frozen OS configuration | update their VM images often |
-| requires renting or acquiring such hardware | are free |
-| requires authentication mechanisms | implement authentication out of the box |
-| requires hardware that can be abused through public PRs &nbsp; | are designed for public PRs |
+| A good benchmark suite.                                        | CI services.                                            |
+| -------------------------------------------------------------- | ------------------------------------------------------- |
+| runs on the same hardware every time                           | provide a different (standardized) machine for each run |
+| runs on dedicated hardware                                     | run on shared resources                                 |
+| runs on a frozen OS configuration                              | update their VM images often                            |
+| requires renting or acquiring such hardware                    | are free                                                |
+| requires authentication mechanisms                             | implement authentication out of the box                 |
+| requires hardware that can be abused through public PRs &nbsp; | are designed for public PRs                             |
 
 <br />
 
@@ -90,7 +90,7 @@ To minimize these effects, benchmarking tools run the tests several times in dif
 schedules and apply some statistics to correct for the inevitable deviations. Or, at least,
 _try_.
 
-# Relative performance measurements with Airspeed Velocity
+## Relative performance measurements with Airspeed Velocity
 
 `scikit-image`, the project that commissioned this task, uses
 [Airspeed Velocity](https://asv.readthedocs.io/), or `asv`, for their benchmark tests.
@@ -108,51 +108,51 @@ functionally we needed. The help message says:
 This sounds like exactly what we are looking for! Let's break down how it works:
 
 1. When we run `asv continuous A B`, `asv` will create at least two<sup>†</sup> virtual environments
-(one per commit) and install revisions A and B in those, respectively. If the project
-involves compiled libraries (as is the case with `scikit-image`), this can be a lengthy
-process!
+   (one per commit) and install revisions A and B in those, respectively. If the project
+   involves compiled libraries (as is the case with `scikit-image`), this can be a lengthy
+   process!
 2. The default configuration will run the benchmark in two interleaved passes, with several
-repeats each. In other words, `asv` will run the suite four times (`A->B->A->B`)! This is done to account
-for the unavoidable deviations from ideality caused from co-running processes, as mentioned above.
+   repeats each. In other words, `asv` will run the suite four times (`A->B->A->B`)! This is done to account
+   for the unavoidable deviations from ideality caused from co-running processes, as mentioned above.
 3. The statistics for each commit are gathered and a report table is presented. The ratio
-of each test is computed and, if it is greater than a certain threshold (`1.2` by default)
-an error is emitted.
+   of each test is computed and, if it is greater than a certain threshold (`1.2` by default)
+   an error is emitted.
 
 > <sup>†</sup> `asv` supports the notion of a configuration matrix, so you can test your code under
-different environments; e.g. NumPy versions, Python interpreters, etc.
+> different environments; e.g. NumPy versions, Python interpreters, etc.
 
 For the benchmark suite of `scikit-image` as of June/July 2021, this ends up taking up to two hours.
 This raises two questions we will answer in the following sections:
 
 1. Although we are trying hard to reduce measurement errors, is that enough? Are these measurements reliable?
 2. Two hours might be too long. Are there any settings we can tune to reduce the runtime
-without reducing the accuracy of the measurements?
+   without reducing the accuracy of the measurements?
 
-# Are CI services reliable enough for benchmarking?
+## Are CI services reliable enough for benchmarking?
 
 We saw above that CI services are not designed for this kind of task, but with some workarounds
 they might be good enough. However, how can we be sure? As data-driven scientists, we say let's run
 an experiment!
 
-## The setup
+### The setup
 
 If our experiment is data-driven, we should generate some data first. This is our strategy:
 
-* We will benchmark and compare two commits that are exactly the same in terms of tested code.
-* Under ideal conditions, we should see that the performance ratio between the two commits is `1.0`.
-In other words, performance should be the same. Of course, these are not ideal conditions, so
-some kind of error is expected. We just want it to stay reliably under an acceptable threshold.
-* We will implement a GitHub Actions workflow that will run every six hours (four times a day) and
-collect results for a week or more. This will help us account for two things:
-    * Accumulate sufficient data points to answer our question.
-    * Account for time factors like different days of the week (e.g. weekday vs weekend),
-      or the time of the day (3am vs 3pm).
-* The workflow will upload the benchmark results as artifacts we can download and process locally
+- We will benchmark and compare two commits that are exactly the same in terms of tested code.
+- Under ideal conditions, we should see that the performance ratio between the two commits is `1.0`.
+  In other words, performance should be the same. Of course, these are not ideal conditions, so
+  some kind of error is expected. We just want it to stay reliably under an acceptable threshold.
+- We will implement a GitHub Actions workflow that will run every six hours (four times a day) and
+  collect results for a week or more. This will help us account for two things:
+  _ Accumulate sufficient data points to answer our question.
+  _ Account for time factors like different days of the week (e.g. weekday vs weekend),
+  or the time of the day (3am vs 3pm).
+- The workflow will upload the benchmark results as artifacts we can download and process locally
   with a Jupyter Notebook.
 
 > Check the [GitHub Actions workflow in this fork](https://github.com/jaimergp/scikit-image/blob/main/.github/workflows/benchmarks-cron.yml)!
 
-## The results
+### The results
 
 To measure the stability of the different benchmark runs we will be looking at the performance
 ratio of the measurements between the two commits. Since they are identical in terms of tested code,
@@ -169,10 +169,10 @@ After collecting data points for 16 days, these are the results:
   an observable y-spread, it is small enough to be considered sensitive to performance regressions
   of more than 50%.](/posts/github-actions-benchmarks/github-actions-benchmark.png)
 
-* Average time taken: 1h55min
-* Minimum and maximum ratios observed: 0.51, 1.36
-* Mean and standard deviation of ratios: 1.00, 0.05
-* Proportion of false positives: 4/108 = 3.7%
+- Average time taken: 1h55min
+- Minimum and maximum ratios observed: 0.51, 1.36
+- Mean and standard deviation of ratios: 1.00, 0.05
+- Proportion of false positives: 4/108 = 3.7%
 
 In the X axis you can see the different runs, sorted by date and time. Days of the week are grouped
 with colored patches for easier visual analysis. In the Y axis, we plot the performance ratio. Each
@@ -189,7 +189,7 @@ more! This is good enough for our project and, in fact, some projects might even
 > If you are curious about how we automatically downloaded the artifacts, parsed the output, and plotted
 > the performance ratios, check the Jupyter Notebook [here](https://gist.github.com/jaimergp/aa4f059c14e394c4089b320cb8b51b1a).
 
-# Can we make it run faster without losing accuracy?
+## Can we make it run faster without losing accuracy?
 
 We just found out that this approach is sensitive enough _but_ it takes two hours to run. Is it possible
 to reduce that time without sacrificing sensitivity? We need to remember that `asv` is running several
@@ -197,25 +197,25 @@ passes and repeats to reduce the measurement error, but maybe some of those defa
 are not needed. Namely:
 
 - The benchmark runs with `--interleave-processes`, but it can be disabled with `--no-interleave-processes`.
-The help message for this flag says:
+  The help message for this flag says:
 
-    > Interleave benchmarks with multiple processes across commits. This can avoid measurement biases
-    > from commit ordering, can take longer.
+      > Interleave benchmarks with multiple processes across commits. This can avoid measurement biases
+      > from commit ordering, can take longer.
 
-    How much longer? Does it help keep error under control? We should measure that.
+      How much longer? Does it help keep error under control? We should measure that.
 
 - By default, all tests are run several times, with different schedules. There are two
-[benchmark attributes](https://asv.readthedocs.io/en/stable/benchmarks.html#timing-benchmarks)
-that govern these settings: `processes` and `repeat`. `processes` defaults to `2`, which means that
-the full suite will be run twice per commit. If we only do one pass (`processes=1`), we will reduce
-the running time in half, but will we lose too much accuracy?
+  [benchmark attributes](https://asv.readthedocs.io/en/stable/benchmarks.html#timing-benchmarks)
+  that govern these settings: `processes` and `repeat`. `processes` defaults to `2`, which means that
+  the full suite will be run twice per commit. If we only do one pass (`processes=1`), we will reduce
+  the running time in half, but will we lose too much accuracy?
 
 To answer both questions, we added more entries to the data collection workflow shown above by
 [parameterizing the `asv` command-line options](https://github.com/jaimergp/scikit-image/blob/e561996/.github/workflows/benchmarks-cron.yml#L14-L23).
 
 These are the results!
 
-## No process interleaving
+### No process interleaving
 
 Disabling process interleaving should be faster and maybe the accuracy loss is not that bad. But...
 how bad? Here are the results:
@@ -228,12 +228,12 @@ how bad? Here are the results:
   to the performance ratio. Ideal measurements would have a performance ratio of 1.0, since both
   runs returned the exact same performance. In practice this does not happen.](/posts/github-actions-benchmarks/github-actions-benchmark-no-interleaving.png)
 
-* Average time taken: 1h39min
-* Minimum and maximum ratios observed: 0.43, 1.5
-* Mean and standard deviation of ratios: 0.99, 0.07
-* Proportion of false positives: 6/66 = 9.99%
+- Average time taken: 1h39min
+- Minimum and maximum ratios observed: 0.43, 1.5
+- Mean and standard deviation of ratios: 0.99, 0.07
+- Proportion of false positives: 6/66 = 9.99%
 
-## Single-pass with `processes=1`
+### Single-pass with `processes=1`
 
 In this configuration, we expect a drastic 50% running time reduction, since we will only do one pass
 per commit, instead of two. However, the accuracy loss might be too dramatic.Let's see!
@@ -247,23 +247,23 @@ per commit, instead of two. However, the accuracy loss might be too dramatic.Let
   a performance ratio of 1.0, since both runs returned the exact same performance. In practice this
   does not happen.](/posts/github-actions-benchmarks/github-actions-benchmark-single-process.png)
 
-* Average time taken: 1h7min
-* Minimum and maximum ratios observed: 0.51, 2.76
-* Mean and standard deviation of ratios: 1.01, 0.07
-* Proportion of false positives: 8/64 = 12.5%
+- Average time taken: 1h7min
+- Minimum and maximum ratios observed: 0.51, 2.76
+- Mean and standard deviation of ratios: 1.01, 0.07
+- Proportion of false positives: 8/64 = 12.5%
 
 At first sight, those clouds look very spread! The number of false positives is also larger.
 
-## Summary of the strategies
+### Summary of the strategies
 
 Let's take a look at the three strategies now. The main columns are **runtime** and **%FP**
 (percentage of false positives). We want the smallest %FP at the shortest runtime.
 
-| Strategy        | Runtime  &nbsp;| %FP  | Min  | Max  | Mean &nbsp;| Std  |
-|-----------------|---------|-------|------|------|------|------|
-| Default         | 1h55    | 3.7  | 0.51 &nbsp;| 1.36 | 1.00 | 0.05 |
-| No interleaving &nbsp;| 1h39    | 9.99 &nbsp;| 0.43 | 1.50 | 0.99 | 0.07 |
-| Single pass     | 1h07    | 12.5 | 0.51 | 2.76 &nbsp;| 1.01 | 0.07 |
+| Strategy               | Runtime &nbsp; | %FP         | Min         | Max         | Mean &nbsp; | Std  |
+| ---------------------- | -------------- | ----------- | ----------- | ----------- | ----------- | ---- |
+| Default                | 1h55           | 3.7         | 0.51 &nbsp; | 1.36        | 1.00        | 0.05 |
+| No interleaving &nbsp; | 1h39           | 9.99 &nbsp; | 0.43        | 1.50        | 0.99        | 0.07 |
+| Single pass            | 1h07           | 12.5        | 0.51        | 2.76 &nbsp; | 1.01        | 0.07 |
 
 <br />
 
@@ -282,7 +282,7 @@ to make it run in less time.
 > and is noisier from the maintainer perspective, who would need to check all replicas.
 > Not to mention that more replicas increase the chances for more false positives!
 
-# Speeding up compilation times
+## Speeding up compilation times
 
 So far we have only looked at speeding up the benchmark suite itself, but we saw
 earlier that `asv` will also spend some time setting up virtual environments and installing the
@@ -303,7 +303,7 @@ to see how it can be implemented on GitHub Actions.
 
 These two changes together brought the average running time down to around 1h 20min. Not bad!
 
-# Run it on demand!
+## Run it on demand!
 
 Benchmarks do not need to run for every single commit pushed to a PR. In fact, that's probably
 a waste of resources. Instead, we'd like the maintainers to run the benchmarks on demand, whenever
@@ -342,7 +342,7 @@ if more commits have been added to the PR since the label was added. Ideally, th
 added next to the _@user added the run-benchmark label_ message. Maybe in a
 [future update](https://twitter.com/jaime_rgp/status/1412419232340627467)?
 
-# TLDR
+## TLDR
 
 We have seen that GitHub Actions is indeed good enough to perform relative benchmarking in a reliable way
 as long as several passes are averaged together (default behaviour in `asv continuous`). This takes a bit
@@ -352,19 +352,19 @@ to let the maintainers decide when to do it on demand.
 
 ---
 
-# Useful references
+## Useful references
 
-* [scikit-image/scikit-image #5424](https://github.com/scikit-image/scikit-image/pull/5424): The PR where
+- [scikit-image/scikit-image #5424](https://github.com/scikit-image/scikit-image/pull/5424): The PR where
   all this was implemented.
-* [Analysis notebook](https://gist.github.com/jaimergp/aa4f059c14e394c4089b320cb8b51b1a): The code used
+- [Analysis notebook](https://gist.github.com/jaimergp/aa4f059c14e394c4089b320cb8b51b1a): The code used
   to analyze the benchmarking data.
-* [asv.readthedocs.io](https://asv.readthedocs.io): The official documentation for `asv`.
-* [Building an Open Source, Continuous Benchmark System](https://wolfv.medium.com/building-an-open-source-continuous-benchmark-system-717839093962)
-* [Conbench: Language-independent Continuous Benchmarking Tool, by Ursa Labs](https://ursalabs.org/blog/announcing-conbench/)
-* [PyPy Speed](https://speed.pypy.org/)
-* [Pandas Speed](http://pandas.pydata.org/speed/pandas/)
+- [asv.readthedocs.io](https://asv.readthedocs.io): The official documentation for `asv`.
+- [Building an Open Source, Continuous Benchmark System](https://wolfv.medium.com/building-an-open-source-continuous-benchmark-system-717839093962)
+- [Conbench: Language-independent Continuous Benchmarking Tool, by Ursa Labs](https://ursalabs.org/blog/announcing-conbench/)
+- [PyPy Speed](https://speed.pypy.org/)
+- [Pandas Speed](http://pandas.pydata.org/speed/pandas/)
 
-# Acknowledgements
+## Acknowledgements
 
 Thanks Gregory Lee, Stéfan van der Walt and Juan Nunez-Iglesias for their enthusiastic and useful feedback
 in the PR! The plots look that pretty thanks to comments provided by John Lee. Gregory Lee, Gonzalo

--- a/apps/labs/posts/integrating-hypothesis-into-sympy.md
+++ b/apps/labs/posts/integrating-hypothesis-into-sympy.md
@@ -26,7 +26,7 @@ If you wish to follow the examples in the blog post, you will need to have the l
 $ pip install hypothesis
 ```
 
-# What is Property Based Testing?
+## What is Property Based Testing?
 
 Property based testing (PBT) is a technique where instead of testing individual test cases, you specify properties you wish to hold true for a range of inputs. These properties are then tested against automatically generated test data. PBT uses logical properties over generated test data to facilitate broad, robust testing that can expose edge cases not easily found via traditional test cases.
 
@@ -99,6 +99,6 @@ Hypothesis was able to find various bugs and code design flaws. Below I will hig
 - The [`resultant` function returning incorrect answers](https://github.com/sympy/sympy/issues/25406). While this bug ended up not needing to be resolved, it did reveal the utility in having Hypothesis check [consistency between implementations](https://github.com/sympy/sympy/issues/25406#issuecomment-1652243538) of the same function.
 - There were various issues with the lowest common multiple (LCM) function (notes in [issue #25624](https://github.com/sympy/sympy/issues/25624), [PR #25636](https://github.com/sympy/sympy/pull/25636), and [PR #25517](https://github.com/sympy/sympy/pull/25517#issuecomment-1714474991)), the biggest being when the LCM should make use of the integer implementation vs polynomial implementation (when the defined polynomial is essentially an integer).
 
-# Acknowledgements
+## Acknowledgements
 
 Thank you to my mentors [Aaron](https://github.com/asmeurer) and [Matthew](https://github.com/honno) for guidance during this project. Added thanks to [Melissa](https://github.com/melissawm) and the general internship program for their support.

--- a/apps/labs/posts/ipython-8.0-lessons-learned-maintaining-software.md
+++ b/apps/labs/posts/ipython-8.0-lessons-learned-maintaining-software.md
@@ -154,7 +154,7 @@ This has domino effects in IPython 8.0 as we were going to great length to
 support top level async which is since 3.8 native to Python. Many simplification
 leading do even more down the line up to complete method and class suppressions.
 
-# Don't be cheap on `DeprecationWarning`s
+## Don't be cheap on `DeprecationWarning`s
 
 Warnings in general are much more powerful and complex than at first look. Once
 you understand them well they are an extremely powerful features. When use

--- a/apps/labs/posts/jupyterlab-winter-theme.md
+++ b/apps/labs/posts/jupyterlab-winter-theme.md
@@ -12,14 +12,14 @@ hero:
   imageAlt: 'An illustration of a light brown hand holding up a microphone, with some graphical elements highlighting the top of the microphone'
 ---
 
-JupyterLab 3.0 is about to be released and provides many 
-improvements to the extension system. Theming is a way to extend JupyterLab and 
+JupyterLab 3.0 is about to be released and provides many
+improvements to the extension system. Theming is a way to extend JupyterLab and
 benefits from those improvements.
 
 While theming is often disregarded as a purely cosmetic endeavour, it can greatly
 improve software. Theming can be great help for accessibility, and the Jupyter team
 pays attention to making the default appearance accessibility-aware by using
-sufficient contrast.  For users with a high visual acuity you may also choose 
+sufficient contrast. For users with a high visual acuity you may also choose
 to increase the information density.
 
 Theming can also be a great way to improve communication by increasing or
@@ -29,15 +29,15 @@ distinction between staging and production.
 
 Finally Theming can be a great way to express oneself, for example, by using
 a branded version of software that fits well into a context, or expressing one's artistic
-preferences or opinions. 
+preferences or opinions.
 
 In the following blog post, we will show you step-by-step how you can
 develop a custom theme for JupyterLab, distribute it, and take the example of the
 [jupyterlab-theme-winter](https://github.com/Quansight-Labs/jupyterlab-theme-winter) theme we release today to celebrate the end of 2020.
 
-# JupyterLab and Themes
+## JupyterLab and Themes
 
-JupyterLab customisation can be done via what are called `Extensions`.  All
+JupyterLab customisation can be done via what are called `Extensions`. All
 behaviors and user interface elements of JupyterLab can be changed by providing
 extensions; this is true for elements that are added to JupyterLab, but also for
 the core components. A Theme is one of those extensions. The default light and dark
@@ -47,7 +47,7 @@ a theme.
 Generally all information about how extensions work in JupyterLab is applicable
 to a theme, though there are a number of optional steps and behaviors that are not
 necessary for themes, and a few configurations that are needed for themes.
-A lot of boilerplate can also be extracted, which makes creating most themes 
+A lot of boilerplate can also be extracted, which makes creating most themes
 simpler that full-fledged extensions.
 
 Let's first see what we are trying to accomplish in a screenshot of the "winter 2020" theme.
@@ -66,16 +66,16 @@ To do so we'll need to:
 
 Optionally, once you are happy with the result, or would like to get feedback from the
 community, you can publish the theme so that people can ~~complain~~ suggest improvements
-and contribute. 
+and contribute.
 
-# Installing JupyterLab
+## Installing JupyterLab
 
-To get started you do not need a development version of JupyterLab.  This can
+To get started you do not need a development version of JupyterLab. This can
 be achieved with:
 
 ```bash
 $ pip install --pre jupyterlab==3.0rc14 jupyter_packaging cookiecutter
-``` 
+```
 
 While we are at it we will need to install nodejs. Because nodejs is _not_ a
 Python package you will need to use conda or another package manager.
@@ -84,7 +84,7 @@ Python package you will need to use conda or another package manager.
 $ conda install nodejs
 ```
 
-# Creating a Theme Extension
+## Creating a Theme Extension
 
 Now the hard part: you have an idea, you need a name. Naming is one of the
 hardest things in development, along with caching results and off-by-one errors,
@@ -101,7 +101,7 @@ $ pip install jupyter_packaging cookiecutter
 
 Normally we would use [theme-cookiecutter](https://github.com/jupyterlab/theme-cookiecutter) but it is not
 yet updated for JupyterLab 3, so we fall back to the more generic
-[extension-cookiecutter-ts](https://github.com/jupyterlab/extension-cookiecutter-ts) 
+[extension-cookiecutter-ts](https://github.com/jupyterlab/extension-cookiecutter-ts)
 and will highlight the specifics of a Theme extension compared to a standard one.
 
 Run `cookiecutter` and provide some information about your extension:
@@ -112,12 +112,12 @@ author_name []: My Name
 python_name [myextension]: jupyterlab-theme-winter
 labextension_name [myextension]: @my-repo/jupyterlab-theme-winter
 project_short_description [A JupyterLab theme extension.]: A winter theme for jupyterlab
-has_server_extension [n]: 
-has_binder [n]: 
-repository [https://github.com/my_name/myextension]: 
+has_server_extension [n]:
+has_binder [n]:
+repository [https://github.com/my_name/myextension]:
 ```
 
-This has created the extension `jupyterlab-theme-winter`.  We can go to the directory and
+This has created the extension `jupyterlab-theme-winter`. We can go to the directory and
 immediately turn it into a git repository.
 
 ```bash
@@ -127,7 +127,7 @@ $ git add .
 $ git commit -am 'initial commit'
 ```
 
-# Building and Installing the Extension
+## Building and Installing the Extension
 
 JupyterLab 3 has focused on make extension authors' lives easier, and it has done a great
 job of it. As a developer, you just need to run a single command to be up and running
@@ -153,7 +153,7 @@ First, replace the content of `src/index.ts` with the following content
 ```js
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
 
 import { IThemeManager } from '@jupyterlab/apputils';
@@ -166,15 +166,17 @@ const extension: JupyterFrontEndPlugin<void> = {
   requires: [IThemeManager],
   autoStart: true,
   activate: (app: JupyterFrontEnd, manager: IThemeManager) => {
-    console.log('JupyterLab extension @quansight-labs/jupyterlab-theme-winter is activated!');
+    console.log(
+      'JupyterLab extension @quansight-labs/jupyterlab-theme-winter is activated!',
+    );
     const style = '@quansight-labs/jupyterlab-theme-winter/index.css';
     manager.register({
       name: 'JupyterLab Winter',
       isLight: true,
       load: () => manager.loadCSS(style),
-      unload: () => Promise.resolve(undefined)
+      unload: () => Promise.resolve(undefined),
     });
-  }
+  },
 };
 
 export default extension;
@@ -183,7 +185,7 @@ export default extension;
 Then in the `package.json`, add `"jupyterlab-theme"` to the list of keywords and ensure that the `jupyterlab` stanza looks like this.
 
 ```json
-  "jupyterlab": { 
+  "jupyterlab": {
     "extension": true,
     "themePath": "style/index.css",
     "outputDir": "jupyterlab_theme_winter/labextension"
@@ -202,33 +204,33 @@ You can switch themes; but as you will see; the current theme is identical to
 the light-theme. Now it's time to modify some values in the `styles/variables.css` file
 with a valid design.
 
-## Design Considerations
+### Design Considerations
 
-In the words of Jurassic Park’s Dr. Ian Malcolm, “Your scientists were so preoccupied with whether they could, 
-they didn't stop to think if they should.” And now that you can modify JupyterLab’s theme to your heart’s content, 
-here is some design advice to help keep you from accidentally creating a theme that visually destroys your 
+In the words of Jurassic Park’s Dr. Ian Malcolm, “Your scientists were so preoccupied with whether they could,
+they didn't stop to think if they should.” And now that you can modify JupyterLab’s theme to your heart’s content,
+here is some design advice to help keep you from accidentally creating a theme that visually destroys your
 workspace like a rampaging tyrannosaurus rex.
 
-### JupyterLab design system
+#### JupyterLab design system
 
-When making a theme, it’s likely you’ll want to change things that already exist in JupyterLab. Much of the UI relies 
-on relevant CSS variables with naming conventions (`--jp-ui-font-color3 ` or `--jp-elevation-z0`) to help you find 
+When making a theme, it’s likely you’ll want to change things that already exist in JupyterLab. Much of the UI relies
+on relevant CSS variables with naming conventions (`--jp-ui-font-color3 ` or `--jp-elevation-z0`) to help you find
 what you need. Think of the system like this:`--jp-region-contenttype-unit1`
 
-- The `--jp` prefix is a constant. 
-- The middle holds various details like what type of UI element it is for, if it is standard (no tag) or if 
-it has a specific use. 
+- The `--jp` prefix is a constant.
+- The middle holds various details like what type of UI element it is for, if it is standard (no tag) or if
+  it has a specific use.
 - `region` is for variables that are only be used in a certain area of the UI .
-- The content type is something like `font` or `border`. It describes the variable based on its use. 
-- The `unit` is the smallest unit of the variable like a color, shadow, or spacing. It is labeled by a number when 
-there is more than one of that unit; `0`s are almost never used, and `1`s are some of the most frequently used. 
-- Whenever a variable name does not have one of these sections, that means it doesn’t have specific rules about 
-its use in that area.
+- The content type is something like `font` or `border`. It describes the variable based on its use.
+- The `unit` is the smallest unit of the variable like a color, shadow, or spacing. It is labeled by a number when
+  there is more than one of that unit; `0`s are almost never used, and `1`s are some of the most frequently used.
+- Whenever a variable name does not have one of these sections, that means it doesn’t have specific rules about
+  its use in that area.
 
 Common labels you might want to know:
 
-- `layout` is used for large areas of the interface, especially backgrounds. 
-- `inverse`  indicates the opposite color scale of the rest of the UI. For example in
+- `layout` is used for large areas of the interface, especially backgrounds.
+- `inverse` indicates the opposite color scale of the rest of the UI. For example in
   light mode, inverse `0` and `1` are dark instead of light.
 - `elevation` and `z` are for shadows. While these might not be the main things
   you want to change, their unfamiliar names might make them harder to find.
@@ -238,37 +240,37 @@ There are also variables specific to different types of text and display
 modes, so you could have a theme that looks like the standard light
 theme until you enter Presentation mode.
 
-### Color
+#### Color
 
-Less is more. Choosing a color palette of three or fewer hues can be easier to manage and make the whole interface 
-more cohesive since those colors will likely be repeated across the UI. Try it out; it might be surprising how just 
+Less is more. Choosing a color palette of three or fewer hues can be easier to manage and make the whole interface
+more cohesive since those colors will likely be repeated across the UI. Try it out; it might be surprising how just
 changing a few color variables can create a very different JupyterLab.
 
-A color's value—or how light or dark it is—also determines contrast. Contrast is key to legibility and creating an 
-experience that includes low-vision users. [WCAG color contrast guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast) 
-apply to text and graphic interactive 
-elements. There are many tools available, including [downloadable contrast checkers](https://www.paciellogroup.com/color-contrast-checker/) 
+A color's value—or how light or dark it is—also determines contrast. Contrast is key to legibility and creating an
+experience that includes low-vision users. [WCAG color contrast guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)
+apply to text and graphic interactive
+elements. There are many tools available, including [downloadable contrast checkers](https://www.paciellogroup.com/color-contrast-checker/)
 and [web app versions](https://userway.org/contrast/000000/ffffff).
 
-### Text
+#### Text
 
-JupyterLab is full of text, so this can be a place for major changes with very little code. You can easily change font, 
-color, spacing, and size. It's a good idea not have text below 10pt in size, or smaller than the default 
-[`--jp-ui-font-size0`](https://github.com/jupyterlab/jupyterlab/blob/083c65d92686d23b813f0242fca5be3d8b6fae37/packages/theme-light-extension/style/variables.css#L107) 
+JupyterLab is full of text, so this can be a place for major changes with very little code. You can easily change font,
+color, spacing, and size. It's a good idea not have text below 10pt in size, or smaller than the default
+[`--jp-ui-font-size0`](https://github.com/jupyterlab/jupyterlab/blob/083c65d92686d23b813f0242fca5be3d8b6fae37/packages/theme-light-extension/style/variables.css#L107)
 (and it's an accessibility recommendation).
 
-### Icons
+#### Icons
 
-JupyterLab's icons live in the [packages directory](https://github.com/jupyterlab/jupyterlab/tree/083c65d92686d23b813f0242fca5be3d8b6fae37/packages/theme-light-extension/style/icons) 
-and are part of or based on [Material Icons](https://material.io/resources/icons/?search=clos&icon=warning&style=round). 
-If you want to change or add icons and keep them matching, finding one from this system will fit best. The [Material Design system](https://material.io/design/iconography/system-icons.html) 
-also points out some of their icon design principles which are good to follow if you need to make custom icons that 
-match with the rest. Use SVGs, not PNGs, and remember to give it a [tooltip](https://en.wikipedia.org/wiki/Tooltip). 
+JupyterLab's icons live in the [packages directory](https://github.com/jupyterlab/jupyterlab/tree/083c65d92686d23b813f0242fca5be3d8b6fae37/packages/theme-light-extension/style/icons)
+and are part of or based on [Material Icons](https://material.io/resources/icons/?search=clos&icon=warning&style=round).
+If you want to change or add icons and keep them matching, finding one from this system will fit best. The [Material Design system](https://material.io/design/iconography/system-icons.html)
+also points out some of their icon design principles which are good to follow if you need to make custom icons that
+match with the rest. Use SVGs, not PNGs, and remember to give it a [tooltip](https://en.wikipedia.org/wiki/Tooltip).
 Most of all, make sure to give it an ARIA label (like [this recommendation](https://gomakethings.com/icon-accessibility-and-aria-label/)).
 
-# Modifying the Theme Variables
+## Modifying the Theme Variables
 
-After each modification the watch process will build the extension for you. 
+After each modification the watch process will build the extension for you.
 No need to stop and restart JupyterLab server; simply refresh the page.
 
 Now we are going to modify some values in the file `variables.css` in our
@@ -276,9 +278,9 @@ project. This file controls many of the colors of JupyterLab, and is a nice plac
 to start to change the overall color scheme before doing more detailed
 customisation.
 
-We'll try to update the current theme from orange and blue to more blue-ish tones, 
+We'll try to update the current theme from orange and blue to more blue-ish tones,
 which tend to remind us of the holiday
-season.  Afterward, in the `diff`, see how we changed some of the colors:
+season. Afterward, in the `diff`, see how we changed some of the colors:
 
 ```diff
 diff --git a/style/variables.css b/style/variables.css
@@ -306,7 +308,7 @@ snowman instead of a blue dot. Using the browser inspector, we can look at the C
 doing this and override it in my theme:
 
 ```diff
-@@ -368,0 +369,26 @@                                                                  
+@@ -368,0 +369,26 @@
 +
 +.jp-DirListing-item.jp-mod-running .jp-DirListing-itemIcon:before {
 +    content: '\2603'; /* snowman */
@@ -316,21 +318,21 @@ doing this and override it in my theme:
 +}
 ```
 
-We can also add backgrounds to many of the panels.  By adding a file `snowflakepatterns.svg` to our style directory,
+We can also add backgrounds to many of the panels. By adding a file `snowflakepatterns.svg` to our style directory,
 we can now refer to it from our file and add the following CSS to include snowflakes in the background of
 our directory listing.
 
 ```css
 /* DirListing */
 
-body[data-jp-theme-name="JupyterLab Winter"] .jp-DirListing-content {
+body[data-jp-theme-name='JupyterLab Winter'] .jp-DirListing-content {
   background-image: url('./snowflakepattern.svg');
- }
+}
 ```
 
-# Awesome!
+## Awesome!
 
-[Here](https://github.com/Quansight-Labs/jupyterlab-theme-winter) is the final result, jupyterLab-theme-winter theme provided by Quansight.  Feel
+[Here](https://github.com/Quansight-Labs/jupyterlab-theme-winter) is the final result, jupyterLab-theme-winter theme provided by Quansight. Feel
 free to modify it, and please suggest some themes you might like and share
 in the comments. For example we'd love to see a "summer 2020 theme" for our Southern Hemisphere friends.
 We will dive into how to distribute your themes and make them high-quality in a later blog post.
@@ -341,4 +343,3 @@ And as a bonus, a [Christmas theme](https://github.com/Quansight-Labs/jupyterlab
 at the bottom of your notebooks!
 
 [![Screenshot of JupyterLab Christmas Theme](/posts/jupyterlab-winter-theme/jupyterlab-theme-christmas.png)](https://github.com/Quansight-Labs/jupyterlab-theme-christmas)
-

--- a/apps/labs/posts/metadsl-talk.md
+++ b/apps/labs/posts/metadsl-talk.md
@@ -12,64 +12,58 @@ hero:
   imageAlt: 'An illustration of a brown hand holding up a microphone, with some graphical elements highlighting the top of the microphone.'
 ---
 
-# metadsl PyData talk
- 
 PyData NYC just ended and I thought it would be good to collect my thoughts on [`metadsl`](https://metadsl.readthedocs.io/en/latest/) based on the many conversations I had there surrounding it. This is a rather long post, so if you are just looking for some code [**here is a Binder link for my talk**][binder]. Also, here is the talk I gave a month or so later on the same topic in Austin:
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/cdWdTPL7zrg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-
 ## What is `metadsl`?
- 
+
 ```python
 class Number(metadsl.Expression):
    @metadsl.expression
    def __add__(self, other: Number) -> Number:
        ...
- 
+
    @metadsl.expression
    @classmethod
    def from_int(cls, i: int) -> Number:
        ...
- 
- 
+
+
 @metadsl.rule
 def add_zero(y: Number):
    yield Number.from_int(0) + y, y
    yield y + Number.from_int(0), y
 ```
- 
- --- TEASER_END ---
+
+--- TEASER_END ---
 
 It's a system for creating DSLs (domain specific languages) in Python so that you can separate your API from its implementation. I wrote [a previous blog post showing how to create a system like `metadsl` from the ground up in Python][previous-post]. The premise is that we are looking to a future (and present) where Python is used to build up a computation which is compiled and executed with other systems. Examples of this today are systems like Tensorflow, [Numba][numba], and [Ibis][ibis].
- 
+
 There are currently many different approaches to writing deeply embedded DSLs in Python. `metadsl`s main differentiator is that it piggybacks on Python's existing static typing community. All code written in `metadsl` should be statically analyzable with MyPy and its ilk. We define the language using Python's existing mechanisms of class and functions with type annotations. We also support writing rewrite rules, using regular Python code that is also statically analyzable. So instead of defining a separate API for describing your nodes in your graph, their signatures, and how to replace them with other nodes, you just write Python functions and expressions.
- 
+
 Why would we limit ourselves to essentially a restricted subset of Python's flexibility when it has such great support for flexible metaprogramming and magic? It's so that users of the library can keep the same abstractions that they know from Python. It ties it closer conceptually to the language itself and pushes any type level improvements to happen at the `typing`/`mypy` level. So that `metadsl` moves in accordance with the language itself. It also means we are more restricted in what we can support, but sometimes bounds are helpful to limit scope and possible options.
- 
+
 **TLDR**: `metadsl` is a framework to write domain specific languages in Python that piggybacks on the standard type annotation semantics.
- 
- 
+
 ## How did your talk go?
- 
+
 This was my first time to present `metadsl`, although really a year earlier Travis and I [co-presented on a previous incarnation of the project][uarray-talk]. I imagine at some point the recording will be published, but until then you can run through my talk by playing with [this][binder] notebook on Binder. I appreciated the opportunity to try to place this project in some historical context. I think once I got to the actual code example though, I could have done a better job actually explaining how the system worked and what its limitations are. But it did give me leaping off point to have many great conversations with folks afterwards, which I will summarize below.
- 
+
 ## What are the remaining technical hurdles?
- 
+
 Many! :D
- 
- 
+
 ### Debugging
- 
+
 I was very glad to bump into [Martin Hirzel][martin] again. He presented [a great poster at PLDI][pldi-poster] a year and a half ago, outlining some issues with using a variety of probabilistic programming libraries in Python. Each, for example, has their own abstractions for things like arrays or variables, that users have to re-learn as they switch between them. Users also don't get the same sort of debugging or tracebacks when using these libraries, as they do with regular Python, which leads to a worse user experience.
- 
+
 But he was here at PyData presenting a new system, called [Lale][lale], which allows you to declaratively specify your machine learning pipeline and leave out hyperparameters which you don't know. Then you can feed this to an automatic meta learning system like TPOT which will optimize these. Watch for him on a future Open Source Directions webinar presenting this work!
- 
- 
+
 We talked about how we might add better debugging to `metadsl`. Ideally, we would be able to track back errors to the line where the user entered the expression. So even if they compile to say LLVM, and the code throws some error, it would be good to point out that error to where the user originally wrote the code. To do this, we would have to track the file, line, and column for every expression creation and propagate those along as we do replacements. We should look to Swift for some guidance here, because I know they have spent some effort making sure their compiler preserves source location as it compiles.
- 
+
 ### Mathematical soundness
- 
+
 Another person asked a good question after the presentation, "What if two rules match? Which gets chosen?" At the moment it's a manual process, where you define groups of rules that all should fire at the same time, so should be confluent and then put those groups in series. Like a number of compiler passes. However, we can't prove that two rules won't both match the same objects, leading to indeterminism, or that there are enough rules defined so that the result will actually be replaced, leading to an error. It would be nice to be able to say these things statically.
 
 For example, here is an optimization rule that should execute before, say, compiling to LLVM rules:
@@ -83,103 +77,86 @@ def add_zero(y: Number):
     yield Number.from_int(0) + y, y
     yield y + Number.from_int(0), y
 ```
- 
- There is lots of existing research in the pattern matching and lambda calculus community on being able to answer these questions. However, to get to those systems it would be good to first make our pattern matching system more restricted. Currently, we can define "pure" rules, which have strictly structural matching, and "unpure" rules which execute arbitrary Python functions to determine the replacement. The unpure rules will be very hard to reason about mathematically, unless we decide to model all of Python, which seems like a bad idea. So if we can move more, if not all, of our system to pure replacements then we can have more luck analyzing them. I have a couple of ideas here:
- 
-* One use case for unpure functions is to check if a certain python value has some **property**. Like checking if a integer is 0 to execute some optimization. Even if we don't wanna be able to prove anything about the actual details of these properties, we could model them as pre-checks for the substitution based on deterministic functions on the values.
-* Another is to wrap/unwrap from **values in the host language** of Python. We need this at the edges of the system, for example to unwrap tuples or replace based on which Python type is found. I don't think we can avoid this part. However, by making sure we limit it to the edges, we could still possibly prove things about the inside of the system.
-* We also [embed a **simply typed lambda calculus** into the language itself and implement beta reduction by replacing variables in the subtree][metadsl-abstraction]. Beta reduction is impure, because we are doing a recursive find and replace on the subtree. Creation, from a Python function, is impure not only because it calls a Python callable, but also because it generates a "Variable" with a unique ID to save as the param for the function.
-* In order to compile a functional data flow expression to an imperative control flow graph we need to order our expressions. More details can be found in ["Optimizing compilation with the Value State Dependence Graph"][dataflow-paper] paper. It's hard for me at the moment to imagine this kind of transformation in a pure pattern replacement.
- 
- 
+
+There is lots of existing research in the pattern matching and lambda calculus community on being able to answer these questions. However, to get to those systems it would be good to first make our pattern matching system more restricted. Currently, we can define "pure" rules, which have strictly structural matching, and "unpure" rules which execute arbitrary Python functions to determine the replacement. The unpure rules will be very hard to reason about mathematically, unless we decide to model all of Python, which seems like a bad idea. So if we can move more, if not all, of our system to pure replacements then we can have more luck analyzing them. I have a couple of ideas here:
+
+- One use case for unpure functions is to check if a certain python value has some **property**. Like checking if a integer is 0 to execute some optimization. Even if we don't wanna be able to prove anything about the actual details of these properties, we could model them as pre-checks for the substitution based on deterministic functions on the values.
+- Another is to wrap/unwrap from **values in the host language** of Python. We need this at the edges of the system, for example to unwrap tuples or replace based on which Python type is found. I don't think we can avoid this part. However, by making sure we limit it to the edges, we could still possibly prove things about the inside of the system.
+- We also [embed a **simply typed lambda calculus** into the language itself and implement beta reduction by replacing variables in the subtree][metadsl-abstraction]. Beta reduction is impure, because we are doing a recursive find and replace on the subtree. Creation, from a Python function, is impure not only because it calls a Python callable, but also because it generates a "Variable" with a unique ID to save as the param for the function.
+- In order to compile a functional data flow expression to an imperative control flow graph we need to order our expressions. More details can be found in ["Optimizing compilation with the Value State Dependence Graph"][dataflow-paper] paper. It's hard for me at the moment to imagine this kind of transformation in a pure pattern replacement.
+
 For these last two, we should talk to folks from the term rewriting and lambda calculus communities. In particular, the ["International Conference on Formal Structures for Computation and Deduction"][fscd] seems like an appropriate venue to look into:
- 
+
 > FSCD covers all aspects of formal structures for computation and deduction from theoretical foundations to applications. Building on two communities, RTA (Rewriting Techniques and Applications) and TLCA (Typed Lambda Calculi and Applications), FSCD embraces their core topics and broadens their scope to closely related areas in logics, models of computation (e.g. quantum computing, probabilistic computing, homotopy type theory), semantics and verification in new challenging areas (e.g. blockchain protocols or deep learning algorithms).
- 
- 
+
 There is also [a long history of approaches in trying to compile simply typed lambda calculus using term rewriting systems][lambda-term].
- 
- 
+
 ### Python Control Flow
- 
- 
+
 It was really nice to meet Joe Jevnik for the first time. He has a ton of experience hacking on Python to make things faster and was one of the original contributors to the Blaze project at Continuum.
- 
-Currently, `metadsl` creates expressions just by executing Python functions. This is nice and simple, but it doesn't let us map Python control flow, like `if`, `for`, and list comprehensions, to a functional form.  Joe said we could modify the CPython interpreter to be able to transform these things ([`codetransformer`][codetransformer]). I like this method more than AST or bytecode parsing since it should work without access to the source and we don't need to put our computation in a function.
- 
- 
+
+Currently, `metadsl` creates expressions just by executing Python functions. This is nice and simple, but it doesn't let us map Python control flow, like `if`, `for`, and list comprehensions, to a functional form. Joe said we could modify the CPython interpreter to be able to transform these things ([`codetransformer`][codetransformer]). I like this method more than AST or bytecode parsing since it should work without access to the source and we don't need to put our computation in a function.
+
 Tiark Rompf and some folks at Google have been exploring a similar space, in their ["The 800 Pound Python in the Machine Learning Room" paper][rompf-paper] and [`snek-LMS`][snek-lms] repo:
- 
+
 ![][snek-image]
- 
- 
- 
+
 This is a great area of future work, exploring how we can map Python control flow to `metadsl` expressions to get closer to the expressiveness of things like Numba or Tensorflow. It's much nicer for users to be able to write `if: ..else: ...` instead of a functional `if_(true_clause, false_clause)`.
- 
- 
+
 ## Where should this be used?
- 
+
 This was the second time talking to Mati Picus about this work. He works on NumPy as well as PyPy so has an interesting perspective on how tools like this could make it easier to create alternative runtimes for Python. One major difference between this work and PyPy is that we are limiting ourselves here to creating and compiling domain specific languages in Python, instead of all of Python. Not only does this mean we can deal with a restricted object model, but we can also co-design our libraries to work with this system. PyPy's job is much harder, having to interpret the full complexity of Python and the creative ways existing libraries use it.
- 
- 
+
 ### MLIR
- 
- 
+
 He also was wondering about the relationship with MLIR, a new project from Chris Lattner and Google to provide a meta-IR to describe translations between things like the Tensorflow Graph and LLVM. I was really excited to see this announced last year at the Compilers for Machine Learning conference, because it made me think that maybe this whole "lets share infrastructure to describe our IRs even if we know we need multiple ones" isn't totally crazy. I see `metadsl` as another take on the same idea, but focusing on Python first friendliness whereas with MLIR you use C++ (at least this is what I have seen so far).
- 
-I do want  to investigate it though and see what are the main differences. One key question I have is, "Can you make a simply typed lambda calculus dialect in MLIR?" `metadsl` was designed to allow this to facilitate compiling things like the Mathematics of Arrays which represents arrays as functions from indices to values.
- 
+
+I do want to investigate it though and see what are the main differences. One key question I have is, "Can you make a simply typed lambda calculus dialect in MLIR?" `metadsl` was designed to allow this to facilitate compiling things like the Mathematics of Arrays which represents arrays as functions from indices to values.
+
 It would be nice to see if we could convert between MLIR dialects and `metadsl`. And long term, if we could open a dialogue there and come together into one system in the end, that would be ideal!
- 
+
 I have already started experimenting with translating `metadsl` types into JSON with the `typez` project. That's useful because then we could possibly generate these `typez` descriptions from MLIR dialects and then from there auto-generate Python code. Or vice versa.
- 
+
 I think for now we should focus on doing something useful with `metadsl` first, to really stress test it, then we can come back and see how to bridge that gap.
- 
- 
+
 ### Dataframes
- 
+
 Which brings me to the most practically relevant conversations.Dataframes!
- 
+
 I was excited to reconnect with Marc Garcia, after meeting him a few years ago at SciPy. Congratulations to him for being awarded the Project Sustainability award at the NumFOCUS Summit the weekend before PyData NYC! He ran a docs sprint for Pandas that drew 500 people and is mentoring 26 women new to contributing to Pandas.
- 
+
 We talked about how we could think about targeting different backends and optimizing Pandas. His notion is that they are already exploring this for small chunks of computation. Like adding a `backend` flag to some larger operations to run them through different systems. They just implemented this for plotting as well. He said to move Pandas anywhere, it has to be incremental, that a full rewrite would be less likely to succeed.
- 
+
 I was also thrilled to meet Jeff Reback for the first time. Jeff heroically helps manage the Pandas and Ibis projects, answering your issues and merging your pull requests. If you haven't heard of Ibis yet, it's a lazy Pandas project that can target different backends, like SQL databases. At Quansight, Ivan Ogasawara has implemented a [backend for the OmniSci GPU database][ibis-omnisci], so that you can run queries over millions of rows very quickly from Python with a familiar API. This seems like a nice project to see if `metadsl` has legs.
- 
- 
+
 We should take a look at C# LINQ for inspiration here, to see how they had to update their type system to support it. We will have to also upstream some of [these changes][python-typing-dataframe] to Python's core typing.
- 
+
 ## Long term implications
- 
+
 By describing our APIs with `metadsl` we transform our code into structured data.
- 
- 
+
 ### Reproducible Science
- 
+
 Then, if we save this data, we are able to later analyze it semantically. For example, we can determine what data files were used to produce a certain visualization in a notebook if we output the computation graph alongside the result. This dovetails with [work we have been doing in JupyterLab to support viewing linked data][metadata-explorer] with [Paco Nathan][paco], [the NYU Coleridge Initiative][nyu], and CalPoly.
- 
+
 ![screenshot of JupyterLab metadata creation][jupyterlab-metadata].
- 
+
 I sadly missed [the talk by Evan Patterson on "Semantic modeling of data science code"][semantic-talk] also at PyData that seemed to be going down this same route, but instead by creating separate schemas for the API code. The difference here is that if libraries adopt `metadsl` then we get a defined ontology for free.
- 
+
 ### Statistical Code Optimizations
- 
+
 By creating an extensible rewrite and compilation system we make it possible to experiment with new types of whole-program optimizations on existing codebases. We are starting to see an increase in machine learning in the compilation process itself ([Tensor Comprehensions][tc], [TVM][tvm], ["Machine Learning in Compiler Optimization"][compiler-ml]). As our hardware and software stacks get more complicated it becomes harder to reason about optimization strictly from first principles. So we can [use tools from statistics, like Bayesian Optimization, to optimize our compilation][bayesian].
- 
+
 I went to a talk last week by [David Blei][blei], a pioneer in the probabilistic models and causal inference space. Causal inference lets us try to understand the effect of actions based on previous data from the world:
- 
+
 ![Picture of talk][blei-pic]
- 
+
 I would love to experiment with these tools to help users compile fast code across different architectures, but first we need to create space in the eocsystem to prototype them and get them into users' hands.
- 
- 
+
 ## Wanna get involved?
- 
+
 This project is at an early state and would benefit from collaboration. If you want to get involved, please open an issue on the repo or reach out to me directly. As a Python ecosystem I hope we can come together to work towards solutions in this space.
- 
- 
- 
- 
+
 [python-typing-dataframe]: https://github.com/python/typing/issues/685
 [metadata-explorer]: https://github.com/jupyterlab/jupyterlab-metadata-service/
 [paco]: https://derwen.ai/paco

--- a/apps/labs/posts/portable-python-env.md
+++ b/apps/labs/posts/portable-python-env.md
@@ -22,7 +22,7 @@ environment on the remote machine and recreate it on our local machine.
 While conda relieves the package dependency challenge, it can be hard to
 reproduce the exact same environment.
 
-# Creating a Portable Python Environment
+## Creating a Portable Python Environment
 
 This walkthrough will demonstrate a method to copy an exact environment on
 one machine and transfer it to a another machine. We'll start by collecting

--- a/apps/labs/posts/python-library-function-usage.md
+++ b/apps/labs/posts/python-library-function-usage.md
@@ -17,12 +17,12 @@ understanding how others utilize their libraries. Having better data of
 when and how functions are being used has many benefits. Some of these
 are:
 
-  - better API design
-  - determining whether or not a feature can be deprecated or removed.
-  - more instructive tutorials
-  - understanding the adoption of new features
+- better API design
+- determining whether or not a feature can be deprecated or removed.
+- more instructive tutorials
+- understanding the adoption of new features
 
-# Python Namespace Inspection
+## Python Namespace Inspection
 
 We wrote a general tool
 [python-api-inspect](https://github.com/Quansight-Labs/python-api-inspect)
@@ -34,8 +34,7 @@ for [pandas](https://pandas.pydata.org/),
 [NumPy](https://www.numpy.org/), and
 [SciPy](https://www.scipy.org/). The previously mentioned work used
 regular expressions to search for method usage. The primary issue with
-this approach is that it cannot handle `import numpy.random as rand;
-rand.random(...)` unless additional regular expressions are
+this approach is that it cannot handle `import numpy.random as rand; rand.random(...)` unless additional regular expressions are
 constructed for each case and will result in false
 positives. Additionally,
 [BigQuery](https://cloud.google.com/bigquery/) is not a free resource.
@@ -125,7 +124,7 @@ depend on numpy. This would not be possible without the [libraries.io
 API](https://libraries.io/api). It is a remarkable project which
 deserves more attention.
 
-# Results
+## Results
 
 The table below summarizes the findings of namespace usage within all
 `*.py` files, all `*.py` in only test directories, all `*.py` files

--- a/apps/labs/posts/pytorch-ignite-distributed.md
+++ b/apps/labs/posts/pytorch-ignite-distributed.md
@@ -43,7 +43,7 @@ minimal code change.
   - [References](#references)
   - [Next Steps](#next-steps)
 
-# Prerequisites
+## Prerequisites
 
 This blog assumes you have some knowledge about:
 
@@ -60,7 +60,7 @@ This blog assumes you have some knowledge about:
     [blog](https://labs.quansight.org/blog/2020/09/pytorch-ignite/) for
     a quick high-level overview.
 
-# Introduction
+## Introduction
 
 [PyTorch-Ignite's](https://github.com/pytorch/ignite)
 [ignite.distributed](https://pytorch.org/ignite/distributed.html)
@@ -102,14 +102,14 @@ it without any changes to the code, in particular:
 More information on launchers experiments can be found
 [here](https://github.com/sdesrozis/why-ignite).
 
-# 🔥 Pytorch-Ignite Unified Distributed API
+## 🔥 Pytorch-Ignite Unified Distributed API
 
 We need to write different code for different distributed backends. This
 can be tedious especially if you would like to run your code on
 different hardware configurations. Pytorch-Ignite's `idist` will do all
 the work for you, owing to the high-level helper methods.
 
-## 🔍 Focus on the helper `auto_*` methods:
+### 🔍 Focus on the helper `auto_*` methods:
 
 - [auto_model()](https://pytorch.org/ignite/distributed.html#ignite.distributed.auto.auto_model)
 
@@ -142,7 +142,6 @@ distributed model instantiation:
          </tr>
       </table>
    </div>
-
 
 Additionally, it is also compatible with
 [NVIDIA/apex](https://github.com/NVIDIA/apex)
@@ -232,13 +231,14 @@ step:
    </div>
 
 **Note**
-- Additionally, `idist` provides collective operations like `all_reduce`,
-`all_gather`, and `broadcast` that can be used with all supported
-distributed frameworks. Please, see [our
-documentation](https://pytorch.org/ignite/distributed.html#ignite-distributed-utils)
-for more details.
 
-# Examples 
+- Additionally, `idist` provides collective operations like `all_reduce`,
+  `all_gather`, and `broadcast` that can be used with all supported
+  distributed frameworks. Please, see [our
+  documentation](https://pytorch.org/ignite/distributed.html#ignite-distributed-utils)
+  for more details.
+
+## Examples
 
 The code snippets below highlight the API's specificities of each of
 the distributed backends on the same use case as compared to the `idist`
@@ -257,7 +257,7 @@ production-grade example that uses PyTorch-Ignite, refer
 The complete source code of these experiments can be found
 [here](https://github.com/pytorch-ignite/idist-snippets).
 
-## PyTorch-Ignite - Torch native Distributed Data Parallel - Horovod - XLA/TPUs
+### PyTorch-Ignite - Torch native Distributed Data Parallel - Horovod - XLA/TPUs
 
    <div>
       <table>
@@ -290,8 +290,9 @@ The complete source code of these experiments can be found
    </div>
 
 **Note**
+
 - You can also mix the usage of `idist` with other distributed APIs as
-below:
+  below:
 
 ```python
 dist.init_process_group(backend, store=..., world_size=world_size, rank=rank)
@@ -303,7 +304,7 @@ model = idist.auto_model(model)
 dist.destroy_process_group()
 ```
 
-# Running Distributed Code
+## Running Distributed Code
 
 PyTorch-Ignite's `idist` also unifies the distributed codes launching
 method and makes the distributed configuration setup easier with the
@@ -318,7 +319,7 @@ tools like `torch.distributed.launch`, `slurm`, `horovodrun` by
 initializing the processing group given the `backend` argument only in
 a general way.
 
-## With `torch.multiprocessing.spawn`
+### With `torch.multiprocessing.spawn`
 
 In this case `idist Parallel` is using the native torch
 `torch.multiprocessing.spawn` method under the hood in order to run the
@@ -342,12 +343,12 @@ python -u ignite_idist.py --backend horovod --nproc_per_node 2
 python -u ignite_idist.py --backend xla-tpu --nproc_per_node 8 --batch_size 32
 ```
 
-## With Distributed launchers
+### With Distributed launchers
 
 PyTorch-Ignite's `idist Parallel` context manager is also compatible
 with multiple distributed launchers.
 
-### With torch.distributed.launch
+#### With torch.distributed.launch
 
 Here we are using the `torch.distributed.launch` script in order to
 spawn the processes:
@@ -356,24 +357,25 @@ spawn the processes:
 python -m torch.distributed.launch --nproc_per_node 2 --use_env ignite_idist.py --backend gloo
 ```
 
-### With horovodrun
+#### With horovodrun
 
 ```bash
 horovodrun -np 4 -H hostname1:2,hostname2:2 python ignite_idist.py --backend horovod
 ```
 
 **Note**
+
 - In order to run this example and to avoid the installation procedure,
-you can pull one of PyTorch-Ignite's [docker image with pre-installed
-Horovod](https://github.com/pytorch/ignite/blob/master/docker/hvd/Dockerfile.hvd-base).
-It will include Horovod with `gloo` controller and `nccl` support.
+  you can pull one of PyTorch-Ignite's [docker image with pre-installed
+  Horovod](https://github.com/pytorch/ignite/blob/master/docker/hvd/Dockerfile.hvd-base).
+  It will include Horovod with `gloo` controller and `nccl` support.
 
 ```bash
 docker run --gpus all -it -v $PWD:/project pytorchignite/hvd-vision:latest /bin/bash
 cd project
 ```
 
-### With slurm
+#### With slurm
 
 The same result can be achieved by using `slurm` without any
 modification to the code:
@@ -405,7 +407,7 @@ or using `sbatch script.bash` with the script file `script.bash`:
 srun python ignite_idist.py --backend nccl
 ```
 
-# Closing Remarks
+## Closing Remarks
 
 As we saw through the above examples, managing multiple configurations
 and specifications for distributed computing has never been easier. In

--- a/apps/labs/posts/pytorch-tensoriterator-internals-update.md
+++ b/apps/labs/posts/pytorch-tensoriterator-internals-update.md
@@ -29,7 +29,7 @@ extra details.
 All of the code examples below can be compiled and run in [this GitHub
 repo](https://github.com/kurtamohler/pytorch-TensorIterator-examples).
 
-# Basics of TensorIterator and TensorIteratorConfig
+## Basics of TensorIterator and TensorIteratorConfig
 
 In order to create a `TensorIterator`, a `TensorIteratorConfig` must be created
 first. `TensorIteratorConfig` specifies the input and output tensors that will
@@ -43,7 +43,7 @@ In the following example, a tensor named `out` is configured as the output
 tensor and `a` and `b` are the input tensors. Calling `build` creates the
 `TensorIterator` object from the specified configuration.
 
-``` cpp
+```cpp
 at::TensorIteratorConfig iter_config;
 iter_config
   .add_output(out)
@@ -53,7 +53,7 @@ iter_config
 auto iter = iter_config.build();
 ```
 
-# Performing iterations
+## Performing iterations
 
 Iterations using `TensorIterator` can be classified as point-wise iterations or
 reduction iterations. This plays a fundamental role in how iterations using
@@ -65,7 +65,7 @@ Note that for CUDA, it is possible to parallelize along the reduction
 dimension, but synchronizations are needed to avoid race conditions.
 Parallelization with vectorized operations can also be implemented.
 
-## Iteration details
+### Iteration details
 
 The simplest iteration operation can be performed using the
 [`for_each`](https://github.com/pytorch/pytorch/blob/d9e6750759b78c68e7d98b80202c67bea7ba24ec/aten/src/ATen/TensorIterator.cpp#L677)
@@ -97,7 +97,7 @@ amount' of data to iterate over in order to gain a significant speedup using
 multi-threaded execution. If you want to explicitly specify that your operation
 _must_ run in serial, then use the `serial_for_each` loop.
 
-``` cpp
+```cpp
 at::TensorIteratorConfig iter_config;
 iter_config
   .add_output(out)
@@ -127,7 +127,7 @@ auto copy_loop = [](char** data, const int64_t* strides, int64_t n) {
 iter.for_each(copy_loop);
 ```
 
-### Using kernels for iterations
+#### Using kernels for iterations
 
 Frequently we want to create a kernel that applies a simple point-wise function
 onto entire tensors. `TensorIterator` provides various such generic kernels
@@ -141,7 +141,7 @@ addition of two tensors and stores the result in a third tensor. We can use the
 but you can use one of the `AT_DISPATCH_ALL_TYPES*` macros to support multiple
 data types.
 
-``` cpp
+```cpp
 at::TensorIteratorConfig iter_config;
 iter_config
   .add_output(c)
@@ -162,7 +162,7 @@ output tensor, as long as the inputs strictly broadcast over the output--that
 is, if the output's shape is equal to or greater than the input shape in all
 dimensions.
 
-### Setting tensor iteration dimensions
+#### Setting tensor iteration dimensions
 
 The value of the sizes and strides will determine which dimension of the tensor
 you will iterate over. `TensorIterator` performs optimizations to make sure
@@ -203,7 +203,7 @@ calculates the sum of all elements from the beginning of the vector up to and
 including each position in the input. A 2-D input is treated as a list of
 vectors, and the cumulative sum is calculated for each vector. Higher
 dimensional inputs follow the same logic--everything is just a list of 1-D
-vectors.  So to implement a cumulative sum, we must take into account two
+vectors. So to implement a cumulative sum, we must take into account two
 different strides: the stride between elements in a vector (`result_dim_stride`
 and `self_dim_stride` in the example below) and the stride between each vector
 (`strides[0]` and `strides[1]` in the example below).
@@ -259,7 +259,7 @@ auto loop = [&](char** data, const int64_t* strides, int64_t n) {
 iter.for_each(loop);
 ```
 
-### Helper functions
+#### Helper functions
 
 There are many helper functions within PyTorch that can simplify the creation
 and execution of a `TensorIterator`. We cannot cover all of them in this blog
@@ -325,7 +325,7 @@ auto sum_reduce_loop = [](char** data, const int64_t* strides, int64_t n) {
 iter.for_each(sum_reduce_loop);
 ```
 
-# Conclusion
+## Conclusion
 
 This post was a very short introduction to what `TensorIterator` is actually
 capable of. If you want to learn more about how it works and what goes into

--- a/apps/labs/posts/quansight-labs-awarded-three-czi-eoss-cycle5-grants.md
+++ b/apps/labs/posts/quansight-labs-awarded-three-czi-eoss-cycle5-grants.md
@@ -1,8 +1,8 @@
 ---
-title: "Quansight Labs awarded three CZI EOSS Cycle 5 Grants"
+title: 'Quansight Labs awarded three CZI EOSS Cycle 5 Grants'
 authors: [jaime-rodriguez-guerra]
 published: November 10, 2022
-description: "We are delighted to share details about new grants to support the sustainability of SciPy, conda-forge, and CuPy"
+description: 'We are delighted to share details about new grants to support the sustainability of SciPy, conda-forge, and CuPy'
 category: [Funding, PyData Ecosystem, Packaging, Community]
 featuredImage:
   src: /posts/quansight-labs-awarded-three-czi-eoss-cycle5-grants/blog_feature_czi5.png
@@ -19,11 +19,13 @@ Quansight Labs spends a significant amount of time working on impactful and crit
 Today, we are thrilled to announce that three new EOSS Cycle 5 grants were awarded, in which [Quansight Labs team members are taking a leading role](https://cziscience.medium.com/the-key-to-scientific-breakthroughs-improving-access-to-open-source-software-38f04c14accf).
 
 ## SciPy: Fundamental Tools for Biomedical Research
+
 **PIs: [Matt Haberland](https://github.com/mdhaber) (Cal Poly), [Pamphile Roy](https://github.com/tupui) (Quansight)**
 
 We partnered with [Cal Poly](https://www.calpolycorporation.org/) to improve the scientific Python library [SciPy](https://scipy.org/) towards helping the Biomedical community.
 
 This project has four goals:
+
 1. Improvement of functions used by biomedical software tools
 2. Enhancement of functionality used directly by biomedical researchers
 3. General maintenance, so that dependent projects and researchers can use SciPy with confidence
@@ -54,11 +56,13 @@ The dissemination of scientific knowledge and tools is vital to the open source 
 SciPy is open source, and as such, this grant work will also be done in the open and with the broaders community. It means that you can all contribute to help or provide feedback. Join [our community](https://scipy.org/community/), and help us shape SciPy for the next decade.
 
 ## Transparent, open & sustainable infrastructure for conda-forge and bioconda
+
 **PIs: [Jaime Rodríguez-Guerra](https://github.com/jaimergp) (Quansight), [Wolf Vollprecht](https://github.com/wolfv) (QuantStack)**
 
 This is a joint project with [QuantStack](https://quantstack.net/) to improve [conda-forge](https://conda-forge.org/) and [Bioconda's](https://bioconda.github.io/) sustainability and transparency by adopting vendor-agnostic and secure infrastructure practices. In addition, we will develop comprehensive maintenance metrics and dashboards. 🎉
 
 This project has three main goals:
+
 1. Reducing infrastructure technical debt
 2. Adopting an OCI-based mirroring strategy
 3. Development of a maintenance dashboard on Quetz
@@ -75,35 +79,36 @@ Conda-forge and Bioconda rely on infrastructure and tooling distributed across m
 
 There is no straightforward way to monitor the operational status of conda-forge or Bioconda’s infrastructure. The existing [conda-forge.org/status panel](https://conda-forge.org/status/) is far from giving a comprehensive view of ongoing maintenance tasks, bottlenecks or the overall health of the many bots and infrastructure pieces. Having a detailed picture of the infrastructure and automation tools will significantly improve the maintainers' workflow and aid with identifying critical risks. The dashboard will be built on top of [Quetz](https://quetz.readthedocs.io/en/latest/index.html), an open source server for hosting conda packages, allowing for increased transparency and extensibility.
 
-
 ## Enhancing High-Level Scientific Computing Support in CuPy
+
 **PI: [Kenichi Maehashi](https://github.com/kmaehashi) (Preferred Networks)**
 
-Led by [Preferred Networks](https://www.preferred.jp/en), Quansight Labs is proud to collaborate on this grant, which aims to provide a series of GPU accelerated routines for signal processing and interpolation in CuPy. The goal is to match SciPy’s `signal` and `interpolate` submodules,  as a foundation for the research community. 
+Led by [Preferred Networks](https://www.preferred.jp/en), Quansight Labs is proud to collaborate on this grant, which aims to provide a series of GPU accelerated routines for signal processing and interpolation in CuPy. The goal is to match SciPy’s `signal` and `interpolate` submodules, as a foundation for the research community.
 
 This project has two main goals
+
 1. Develop interpolation and signal processing modules
 2. Maintain CuPy to continue supporting the latest platforms
 
 ### Develop interpolation and signal processing modules
+
 The [CuPy project](https://cupy.dev/) aims to reach full [coverage of the NumPy and SciPy APIs](https://docs.cupy.dev/en/latest/reference/comparison.html). The developers will implement, profile, document, and add unit tests for each API in the targeted modules: `cupyx.scipy.interpolate` and `cupyx.scipy.signal`. This work includes:
 
-
-* Careful analysis of the underlying algorithms will be carried out, and specialized GPU kernels (CUDA C/C++) will be written from scratch when needed.
-* GPU & CPU elapsed implementation time profiling for a variety of GPU devices representing common research environments 
-* Unit tests added to cover all possible input combinations and edge cases, e.g. overflows, exceptions, and warnings
+- Careful analysis of the underlying algorithms will be carried out, and specialized GPU kernels (CUDA C/C++) will be written from scratch when needed.
+- GPU & CPU elapsed implementation time profiling for a variety of GPU devices representing common research environments
+- Unit tests added to cover all possible input combinations and edge cases, e.g. overflows, exceptions, and warnings
 
 ### Maintain CuPy to continue supporting the latest platforms
+
 As with other GPU applications, CuPy heavily relies on NVIDIA CUDA and AMD ROCm libraries. Currently, CuPy supports with CUDA versions (10.2, 11.0-11.6) and four ROCm versions (4.0, 4.2, 4.3, 5.0). GPU vendors generally release updates of these toolkits on a quarterly basis, and providing immediate support for them is essential to allow users to enjoy the latest features, performance enhancements, security, and bug fixes. This work includes:
 
-* Implementing Python wrappers for new APIs added to the library to make them available to CuPy
-* Supporting  new features from a new CUDA or ROCm release, when applicable 
-* Setting up a continuous integration system to provide extensive coverage of the supported software combinations
-* Building a delivery pipeline to provide binary packages for the supported versions of the library
-
+- Implementing Python wrappers for new APIs added to the library to make them available to CuPy
+- Supporting new features from a new CUDA or ROCm release, when applicable
+- Setting up a continuous integration system to provide extensive coverage of the supported software combinations
+- Building a delivery pipeline to provide binary packages for the supported versions of the library
 
 <br />
 
-# Want to join?
+## Want to join?
 
 The projects mentioned in this blog post are open-source community-led projects across the PyData ecosystem. Thanks to this round of CZI funding, Quansight Labs will contribute more to SciPy, conda-forge and CuPy. We also welcome and encourage your help in this endeavor. If you have a particular interest in one of these projects, or are interested in the work we do at Quansight and Quansight Labs, have a look at our [open job postings](https://www.quansight.com/careers). We are a fully remote and globally distributed company. Please don't hesitate to contact us with questions regarding your application.

--- a/apps/labs/posts/release-spyder-4beta2.md
+++ b/apps/labs/posts/release-spyder-4beta2.md
@@ -12,23 +12,23 @@ hero:
   imageAlt: 'An illustration of a brown hand holding up a microphone, with some graphical elements highlighting the top of the microphone.'
 ---
 
-It has been almost two months since I joined Quansight in April, to start 
-working on Spyder maintenance and 
-development. So far, it has been a very exciting and rewarding journey under 
+It has been almost two months since I joined Quansight in April, to start
+working on Spyder maintenance and
+development. So far, it has been a very exciting and rewarding journey under
 the guidance of long time Spyder maintainer
 [Carlos Córdoba](https://github.com/ccordoba12).
-This is the first of a series of blog posts we will be writing to showcase 
-updates on the development of Spyder, new planned features and news on the 
+This is the first of a series of blog posts we will be writing to showcase
+updates on the development of Spyder, new planned features and news on the
 road to Spyder 4.0 and beyond.
 
 First off, I would like to give a warm welcome to
 [Edgar Margffoy](https://github.com/andfoy),
 who recently joined Quansight and will be working with the Spyder team to
-take its development even further. Edgar has been a core Spyder developer 
+take its development even further. Edgar has been a core Spyder developer
 for more than two years now, and we are very excited to have his (almost)
 full-time commitment to the project.
 
-# Spyder 4.0 Beta 2 released!
+## Spyder 4.0 Beta 2 released!
 
 Since August 2018, when the first beta of the 4.x series was released, the
 Spyder development team has been working hard on our next release.
@@ -44,8 +44,8 @@ and numerous other feature enhancements, bug fixes and internal improvements.
 A full-interface dark theme has been a
 [long awaited feature](https://github.com/spyder-ide/spyder/issues/2350),
 and is enabled by default in Spyder 4. You can still select the
-light theme under  ``Preferences > Appearance`` by either choosing a light-background
-syntax-highlighting scheme, or changing ``Interface theme`` to ``Light``.
+light theme under `Preferences > Appearance` by either choosing a light-background
+syntax-highlighting scheme, or changing `Interface theme` to `Light`.
 
 ![Screenshot of the Spyder main window with default panes, with the dark theme applied across the entire interface.](/posts/release-spyder-4beta2/spyder-qdarkstyle.png)
 
@@ -60,7 +60,6 @@ to pursue the release of QDarkStyle 3.x, which will be using Spyder's
 [QtSASS](https://github.com/spyder-ide/qtsass/)
 package to harness the power of SASS/SCSS and allow users to fully customize
 the theme dynamically.
-
 
 ## Language Server Protocol architecture
 
@@ -114,14 +113,14 @@ them.
 There are numerous additional features we've added in the previous 10
 months! These include:
 
-* **Autosave** and **File Recovery** in the editor, so Spyder can restore your
-unsaved files in case it crashes or something else goes wrong.
-* Dedicated **Sympy**, **Cython** and **Pylab** consoles, making it
-very simple to quickly explore and create code for these libraries.
-* OS level **window pane undocking**, allowing you to easily
-organize panes across different monitors.
-* Support for **[multi-indexes](https://pandas.pydata.org/pandas-docs/stable/user_guide/advanced.html)**
-in our Dataframe viewer, making working with complex datasets much easier.
+- **Autosave** and **File Recovery** in the editor, so Spyder can restore your
+  unsaved files in case it crashes or something else goes wrong.
+- Dedicated **Sympy**, **Cython** and **Pylab** consoles, making it
+  very simple to quickly explore and create code for these libraries.
+- OS level **window pane undocking**, allowing you to easily
+  organize panes across different monitors.
+- Support for **[multi-indexes](https://pandas.pydata.org/pandas-docs/stable/user_guide/advanced.html)**
+  in our Dataframe viewer, making working with complex datasets much easier.
 
 We will describe all of these additional enhancements in greater detail in
 future blog posts.
@@ -129,10 +128,10 @@ future blog posts.
 ## You can help!
 
 If would like to help us test this beta release and try out the new features it offers,
-you can! You can install it with ``conda`` (if using Anaconda/Miniconda, as we recommend),
-or with ``pip``; we suggest doing so in a new Conda env or ``virtualenv``/``venv``
+you can! You can install it with `conda` (if using Anaconda/Miniconda, as we recommend),
+or with `pip`; we suggest doing so in a new Conda env or `virtualenv`/`venv`
 so you can easily switch between your existing Spyder install and the Spyder 4 beta.
-For example, to do so with ``conda``, enter the following at the Terminal/Anaconda prompt:
+For example, to do so with `conda`, enter the following at the Terminal/Anaconda prompt:
 
 ```bash
 $ conda create --channel spyder-ide --name spyder-beta spyder=4.0.0b2

--- a/apps/labs/posts/reproducible-builds.md
+++ b/apps/labs/posts/reproducible-builds.md
@@ -36,7 +36,7 @@ some variable elements and your model is incomplete; having a complete model, re
 component to be able to trust the results and build upon it. We are not going to enter into the exact distinction
 between reproducible and replicable, both have their goals and uses.
 
-# Aren't computers reproducible by design?
+## Aren't computers reproducible by design?
 
 One of the prerequisites for reproducibility is to have a deterministic process, and while we tend to think about computers
 as deterministic things, they often are not, and on purpose. Mainly driven by security concerns, a number of processes in
@@ -51,7 +51,7 @@ order they may be listed.
 To obtain a reproducible result, one thus often needs to make sure each step is deterministic and that all the variables
 influencing that process are either controlled or recorded.
 
-# Reproducible artifact build
+## Reproducible artifact build
 
 In IPython 7.16.1 we have tried to removed all sources of variability, by controlling the order in which the files are
 generated, archived in the sdists, their metadata, timestamps, etc. Thus you should be able to go from the commit in the
@@ -61,7 +61,7 @@ been introduced in the released packages. It is also critically useful for effic
 Of course you have to trust that the IPython source itself and its dependencies are devoid of backdoors, but let's move
 one step at a time. Reproducible build artifacts can also have impact on the build and installation process of packages.
 
-# Efficient rebuilds of dependencies
+## Efficient rebuilds of dependencies
 
 Currently IPython depends on many packages: `prompt_toolkit`, `traitlets`, `setuptools`, and more. We also have a number of
 downstream packages, like `ipykernel`, then `jupyter notebook`. When a dependency tree is rebuilt for one reason or another, a change of a
@@ -78,7 +78,7 @@ This can allow breaking rebuild chains by stopping as soon as a dependency rebui
 Thus, reproducible builds are a necessary but not sufficient condition to decrease the time spent by platforms like conda-forge on rebuilding the ecosystem
 for a new version of Python; making new packages available faster.
 
-# Deduplication
+## Deduplication
 
 One rarely mentioned advantage is deduplication. In many cases there are no reasons why artifacts produced by a build
 step would depend on _all_ of their inputs. For example IPython has currently no reason to build differently on Python 3.7,

--- a/apps/labs/posts/rethinking-jupyter-documentation.md
+++ b/apps/labs/posts/rethinking-jupyter-documentation.md
@@ -23,7 +23,7 @@ could use an upgrade. Accessing interactive Documentation when in a Jupyter
 session, and what it could become. At the end I'll link to my current prototype
 if you are adventurous.
 
-# The current limitation for users
+## The current limitation for users
 
 The current documentation of IPython and Jupyter come in a few forms, but mostly
 have the same limitation.
@@ -38,7 +38,6 @@ You can scroll around but that's about it whether in terminal or Notebooks.
 
 Compare it to the same documentation on the NumPy website.
 
-
 <img alt="numpy.linspace on numpy.org" src="/posts/rethinking-jupyter-documentation/numpy-linspace-compare.png" />
 
 On the left is the documentation for NumPy when visiting [the NumPy website](https://numpy.org). Let's
@@ -48,18 +47,17 @@ it is typically reached via `identifier?` or `help(identifier)`
 
 Compared to rendered documentation, the help documentation is:
 
- - Hard to read,
- - Has no navigation,
- - RST Directives have not been interpreted,
- - No inline graphs, no rendered math.
-
+- Hard to read,
+- Has no navigation,
+- RST Directives have not been interpreted,
+- No inline graphs, no rendered math.
 
 There is also no access to non-docstring based documentation, **no narrative**,
 **no tutorials**, **no image gallery or examples**, no search, no syntax
 highlighting, no way to interact or modify documentation to test effects of
 parameters.
 
-# Limitation for authors
+## Limitation for authors
 
 Due to Jupyter and IPython limitations to display documentation I believe
 authors are often contained to document functions.
@@ -82,8 +80,8 @@ This also leads to long discussions about which syntax to use in advanced areas,
 like formulas in [SymPy's docstrings](https://github.com/sympy/sympy/issues/14964).
 
 Many projects have to implement dynamic docstrings; for example to include all
-the parameters a function or class would pass down using ``**kwargs`` (search
-the matplotlib source code for `_kwdoc` for example, or look at the ``pandas.DataFrame`` implementation).
+the parameters a function or class would pass down using `**kwargs` (search
+the matplotlib source code for `_kwdoc` for example, or look at the `pandas.DataFrame` implementation).
 
 This can make it relatively difficult for authors and contributors to properly
 maintain and provide comprehensive docs.
@@ -94,7 +92,7 @@ tool to help there. See for example [vélin](https://github.com/Carreau/velin)
 which attempts to auto reformat and fix common NumPyDoc's format mistakes and
 typos – but that's a subject of a future post.
 
-# Stuck between a Rock and a Hard place
+## Stuck between a Rock and a Hard place
 
 While Sphinx and related projects are great at offering hosted HTML
 documentation, extensive usage of those makes interactive documentation harder
@@ -110,7 +108,7 @@ Hosted websites often may not reflect the locally installed version of the
 libraries and require careful linking, deprecation and narrative around
 platform or version specific features.
 
-# This is fixable
+## This is fixable
 
 For the past few months I've been working on rewriting how IPython (and hence
 Jupyter) can display documentation. It works both in terminal (IPython) and
@@ -121,7 +119,7 @@ understands most directives; it could be customized to understand any new ones:
 
 Above is the (terminal) documentation of `scipy.polynomial.lagfit`, see how the
 single backticks are properly understood and refer to known parameters, it
-detected that  `` `n` `` is incorrect as it should have double backticks; notice
+detected that `` `n` `` is incorrect as it should have double backticks; notice
 the rendering of the math even in terminal.
 
 For that matter technically this does not care as to whether the DocString is
@@ -142,17 +140,16 @@ Images are included, even in the terminal when they are not inline but replaced 
 a button to open them in your preferred viewer (see the `Open with quicklook` in
 the above screenshot).
 
-# The future
-
+## The future
 
 I'm working on a number of other features, in particular:
 
- - rendering of narrative docs – for which I have a prototype,
- - automatic indexing of all the figures and plots –  working but slow right now,
- - proper cross-library referencing and indexing without the need for intersphinx.
-   For example, it is possible from the `numpy.linspace` page to see all pages that
-   reference it, or use `numpy.linspace` in their example section
-   (see previous image).
+- rendering of narrative docs – for which I have a prototype,
+- automatic indexing of all the figures and plots –  working but slow right now,
+- proper cross-library referencing and indexing without the need for intersphinx.
+  For example, it is possible from the `numpy.linspace` page to see all pages that
+  reference it, or use `numpy.linspace` in their example section
+  (see previous image).
 
 And many others, like showing a graph of the local references between functions,
 search, and preference configurability. I think this could also support many

--- a/apps/labs/posts/ruby-wrappers-for-the-xnd-project.mdx
+++ b/apps/labs/posts/ruby-wrappers-for-the-xnd-project.mdx
@@ -42,7 +42,7 @@ hero:
 <br />
 <br />
 
-# Introduction
+## Introduction
 
 Lack of stable and reliable scientific computing software has been a persistent problem
 for the Ruby community, making it hard for enthusiastic Ruby developers to use Ruby in
@@ -98,7 +98,7 @@ existed before the Ruby wrapper). Read on for further details.
 
 All the source code can be found in the [xnd-ruby](https://github.com/xnd-project/xnd-ruby) repo.
 
-# Ndtypes
+## Ndtypes
 
 Ndtypes is the library that is used for defining the shape of data.
 
@@ -106,9 +106,9 @@ Run `gem install ndtypes --pre` for easily installing ndtypes onto your machine.
 been tested with Ruby 2.4.1 so far. The `gem install` will download the C sources and compile
 them by itself.
 
-## Usage
+### Usage
 
-### Basic initialization
+#### Basic initialization
 
 The ndtypes Ruby wrapper provides a simple interface to the ndtypes C library for creating
 complex data shapes with extreme simplicity. For example, for creating an array of 10 `int64`
@@ -125,7 +125,7 @@ terminology for a Ruby `Hash`) with the values as arrays of type `float32` of si
 t = NDT.new "{x: 25 * float32, y: {a: 25 * float64, 25 * float64}}"
 ```
 
-### Concrete Vs. Abstract Types
+#### Concrete Vs. Abstract Types
 
 Ndtypes distinguishes types depending on whether they are abstract or concrete. Abstract types
 can have symbolic values like dimension or type variables and are used for type checking. Concrete
@@ -144,14 +144,14 @@ NDT.typedef "cost", "int32"
 NDT.typedef "graph", "var * var * (node, cost)"
 ```
 
-### Usage via The C API
+#### Usage via The C API
 
 Most of the C API functions of ndtypes deal with creating `NDT` Ruby objects or obtaining
 internal struct data of an `NDT` Ruby object. The complete specification can be found
 in the [ruby_ndtypes.h](https://github.com/xnd-project/xnd-ruby/blob/master/ndtypes/ext/ruby_ndtypes/ruby_ndtypes.h) file. This is the file you should include if you want to use the
 C API in any of your libraries.
 
-## Implementation
+### Implementation
 
 The Ruby wrapper is a wrapper over the libndtypes library. The `NDT` Ruby object is a wrapper
 over a C struct of type `NdtObject` that has the following definition:
@@ -172,7 +172,7 @@ decremented using `ndt_decref()`. Once the refcount reaches the `0` the object i
 destroyed by libndtypes. Of course, `ndt_t` structs allocated via calls to functions like
 `ndt_alloc()` already come with a refcount of 1.
 
-# Xnd
+## Xnd
 
 XND is the main storage library of the project. It uses types defined by ndtypes for defining
 the shape of data and allows users to read and write data into buffers that are of the shape
@@ -184,7 +184,7 @@ functions that are defined within gumath (explained later in this post).
 Similar to the ndtypes wrapper, the xnd Ruby wrapper can be installed with a call to
 `gem install xnd --pre`.
 
-## Basic Usage
+### Basic Usage
 
 The xnd Ruby wrapper is extremely simple to use and provides a single class `XND` for the
 user that interfaces with libxnd. In the simplest case, one can create an XND object as follows:
@@ -286,7 +286,7 @@ to reflect on the parent object), you should use the `XND#dup` method and make a
 can also allocate a data container without storing any data into it using the `XND.empty`
 method as can be seen in the following examples.
 
-### Data Type Support
+#### Data Type Support
 
 As a result of the flexibility provided by the ndtypes type definition interface, xnd is able
 to provide type support for far more flexible data shapes than simply for arrays with fixed
@@ -307,7 +307,7 @@ x
 #	 value= {"x"=>(1.0+20.0i), "y"=>"abc", "z"=>"any"}
 ```
 
-### Missing Values
+#### Missing Values
 
 XND also supports optional data (represented by `nil`). It can be created as follows:
 
@@ -318,12 +318,12 @@ x[INF] = v # assign full slice
 # => [[10.0, nil, 2.0, 100.12], [nil, nil, 6.0, 7.0]]
 ```
 
-### Usage via The C API
+#### Usage via The C API
 
 The primary function of the XND Ruby C API is for creating and querying XND Ruby objects.
 The full API can be found in the [ruby_xnd.h](https://github.com/xnd-project/xnd-ruby/blob/master/xnd/ext/ruby_xnd/ruby_xnd.h) file.
 
-## Implementation
+### Implementation
 
 The implementation of the Ruby wrapper differs from the Python wrapper largely due to nature
 of the garbage collection algorithms employed by both these languages: Ruby uses a mark-and-sweep
@@ -339,7 +339,7 @@ because we only want to save the object in some kind of a global store so that R
 aware of its presence (in case of NDT we use `true` for the value). XND uses three different
 GC guards for various internal objects, which can be found in the [gc_guard.h](https://github.com/xnd-project/xnd-ruby/blob/master/xnd/ext/ruby_xnd/gc_guard.h) file.
 
-# Gumath
+## Gumath
 
 While ndtypes and xnd allow us to define types and memory storage, gumath allows us to actually
 do something with them. The basic idea behind gumath is that it is a library that allows defining
@@ -350,7 +350,7 @@ on the appropriate type. The Ruby interface is a wrapper over the `libgumath` C 
 Some functions (known as kernels) come bundled with libgumath and others can be written fairly
 easily. Similar to the xnd and ndtypes wrappers, the gumath Ruby wrapper can be installed with a call to `gem install gumath --pre`.
 
-## Usage
+### Usage
 
 The `Gumath` class is a top level namespace for various modules that serve as namespaces for
 functions that come rolled in with the libgumath C library. These modules will keep expanding
@@ -372,7 +372,7 @@ z = Gumath::Functions.multiply x, y
 #	 value= [2.0, 6.0, 12.0, 20.0, 30.0, 42.0, 56.0, 72.0]
 ```
 
-### Usage via The C API
+#### Usage via The C API
 
 Since the main purpose of the gumath C API is to allow adding kernels to a Ruby module,
 it provides a single function of the prototype:
@@ -383,7 +383,7 @@ int rb_gumath_add_functions(VALUE module, const gm_tbl_t *tbl);
 
 The `module` parameter is a Ruby object, and `tbl` is a function table of gumath kernels.
 
-## Implementation
+### Implementation
 
 Compared to xnd and ndtypes, the gumath Ruby wrapper is much simpler
 since its primary function is to take functions from libgumath and add them as module
@@ -417,14 +417,14 @@ signify whether the function is a CPU function or a CUDA function (or for that m
 other device that might be added in the future). `identity` is a Ruby object used for identifying
 this function. It is initially set to `nil`.
 
-## Automatic Kernel Generation
+### Automatic Kernel Generation
 
 Writing kernels can be painstaking if you're not familiar with the various functionalities
 that libgumath provides for this purpose. Therefore we also provide a kernel generator
 called [xndtools](https://xnd.readthedocs.io/en/latest/xndtools/index.html#kernel-generator) that allows writing gumath kernels by simply providing the function
 that needs to wrapped. However, this functionality has not yet been tested for Ruby.
 
-# Conclusion and Future Work
+## Conclusion and Future Work
 
 The current state of the Ruby XND wrappers makes them suitable for the XND libraries via Ruby,
 but what would be truly exciting would be have a more Ruby-like API that conforms to accepted

--- a/apps/labs/posts/scipy-ndimage-interpolation.md
+++ b/apps/labs/posts/scipy-ndimage-interpolation.md
@@ -12,7 +12,7 @@ hero:
   imageAlt: 'An illustration of a light brown hand holding up a microphone, with some graphical elements highlighting the top of the microphone.'
 ---
 
-# SciPy n-dimensional Image Processing
+## SciPy n-dimensional Image Processing
 
 SciPy's ndimage module provides a powerful set of general, n-dimensional image processing operations, categorized into areas such as filtering, interpolation and morphology. Traditional image processing deals with 2D arrays of pixels, possibly with an additional array dimension of size 3 or 4 to represent color channel and transparency information. However, there are many scientific applications where we may want to work with more general arrays such as the 3D volumetric images produced by medical imaging methods like computed tomography (CT) or magnetic resonance imaging (MRI) or biological imaging approaches such as light sheet microscopy. Aside from spatial axes, such data may have additional axes representing other quantities such as time, color, spectral frequency or different contrasts. Functions in ndimage have been implemented in a general n-dimensional manner so that they can be applied across 2D, 3D or more dimensions. A more detailed overview of the module is available in the
 [SciPy ndimage tutorial](https://docs.scipy.org/doc/scipy/tutorial/ndimage.html). SciPy's image functions are also used by downstream libraries such as [scikit-image](https://scikit-image.org) to implement higher-level algorithms for things like image restoration, segmentation and registration.

--- a/apps/labs/posts/sparse-array-ecosystem.md
+++ b/apps/labs/posts/sparse-array-ecosystem.md
@@ -12,8 +12,6 @@ hero:
   imageAlt: 'A mind-map of the main components of the sparse array ecosystem'
 ---
 
-# An overview of the Sparse Array Ecosystem for Python
-
 ## Why Sparse Arrays?
 
 ### Sparsity in nature

--- a/apps/labs/posts/sympy-documentation.md
+++ b/apps/labs/posts/sympy-documentation.md
@@ -30,7 +30,7 @@ SymPy](https://oscarbenjamin.github.io/blog/czi/index.html), and to [improve
 its code generation
 capabilities](https://mechmotum.github.io/blog/czi-sympy-wrapup.html).
 
-# Documentation Survey
+## Documentation Survey
 
 To start the project, from November 29, 2021 to January 5, 2022 we ran a short
 survey on the SymPy community, to get a feel for SymPy's documentation needs.
@@ -82,7 +82,7 @@ writing new documentation guides.
 
 Click if you wish to read the [full survey results](https://www.sympy.org/sympy-docs-survey/2021-docs-survey.html).
 
-# Improved Sphinx Theme - Furo
+## Improved Sphinx Theme - Furo
 
 Prior to this project, the SymPy documentation used the "classic" Sphinx
 theme. This is the same theme that is used by the [official Python
@@ -130,7 +130,7 @@ modifying the [Pygments syntax highlighting
 styles](https://github.com/sympy/sympy/blob/master/doc/src/_pygments/styles.py)
 to have better color contrast.
 
-# Improved Organization - Diataxis
+## Improved Organization - Diataxis
 
 A related project was reorganizing the top-level organization of the
 documentation. The SymPy documentation main page used to just consist of a long
@@ -160,7 +160,7 @@ pages](https://docs.sympy.org/latest/reference/index.html) into eight
 sub-categories: Basics, Code Generation, Logic, Matrices, Number Theory,
 Physics, Utilities, and Topics.
 
-# Contribution Documentation
+## Contribution Documentation
 
 One of the most important things an open source project can do to attract new
 contributors is to have good contributor documentation. SymPy has historically
@@ -177,7 +177,7 @@ to be more inline with modern SymPy contribution practices, and to reduce the
 parts that only explain details on how to use Git and GitHub, which are now
 explained better in other sources on the internet.
 
-# Live Documentation Previews on Pull Requests
+## Live Documentation Previews on Pull Requests
 
 A live documentation preview build was added to the SymPy CI so that people
 can easily view how it looks as HTML. While this
@@ -195,12 +195,12 @@ and they will be shown a rendered page like:
 
 ![header on the page that says "This is a preview build from SymPy pull request #25512. It was built against a9765f6. If you aren't looking for a PR preview, go to the main SymPy documentation."](/posts/sympy-documentation/sympy-docs-preview-page.png)
 
-# New Top-level Documentation Guides
+## New Top-level Documentation Guides
 
 In addition to these organizational cleanups, the project involved writing new
 documentation on deprecation, custom functions, best practices, and a glossary.
 
-## New Deprecation Policy
+### New Deprecation Policy
 
 SymPy as a symbolic mathematics system is designed not just as an interactive
 piece of software, but also as a library, which can be used as a dependency in
@@ -260,7 +260,7 @@ to put in the deprecation message, including details on why each deprecation
 was made. The page also gives helpful
 information on [how to silence deprecation warnings](https://docs.sympy.org/dev/explanation/active-deprecations.html#silencing-sympy-deprecation-warnings).
 
-## Guide on Writing Custom Functions
+### Guide on Writing Custom Functions
 
 SymPy comes with hundreds of mathematical functions built-in. But it also
 comes with a standard functionality for users to define their own custom
@@ -298,7 +298,7 @@ SymPy itself. So this guide serves as both a guide to advanced end-users as
 well as a guide to SymPy developers looking to define or extend one of the
 functions that comes with SymPy.
 
-## Guide on SymPy Best Practices
+### Guide on SymPy Best Practices
 
 SymPy has many pitfalls, both for new users and advanced users. The new guide
 on [best practices](https://docs.sympy.org/dev/explanation/best-practices.html)
@@ -327,7 +327,7 @@ The best practices page outlines why one should [avoid string inputs](https://do
 as well as dozens of other best practices
 surrounding both basic and advanced usage of SymPy.
 
-## Glossary of SymPy Terminology
+### Glossary of SymPy Terminology
 
 As a technical library, SymPy makes use of many terms which have a specific
 meaning. If you are not already familiar with SymPy, you might not know what

--- a/apps/labs/posts/whats-new-in-sympy-14.md
+++ b/apps/labs/posts/whats-new-in-sympy-14.md
@@ -53,7 +53,7 @@ While I did not personally work on any of the changes listed below (my work
 for this release tended to be more invisible, behind the scenes fixes), I did
 do the release itself.
 
-# Automatic LaTeX rendering in the Jupyter notebook
+## Automatic LaTeX rendering in the Jupyter notebook
 
 Prior to SymPy 1.4, SymPy expressions in the notebook rendered by default with their
 string representation. To get `LaTeX` output, you had to call `init_printing()`:
@@ -78,7 +78,7 @@ selecting a different printer.
 If you want the string form of an expression for copy-pasting, you can use
 `print`.
 
-# Improved simplification of relational expressions
+## Improved simplification of relational expressions
 
 Simplification of relational and piecewise expressions has been improved:
 
@@ -104,7 +104,7 @@ x = y ∧ y > Max(w, z)
 0
 ```
 
-# Improved MathML printing
+## Improved MathML printing
 
 The MathML presentation printer has been greatly improved, putting it on par
 with the existing Unicode and LaTeX pretty printers.
@@ -124,7 +124,7 @@ presentation form for `Integral(exp(-x**2), (x, -oo, oo))` below:
 
 <br />
 
-# Improvements to solvers
+## Improvements to solvers
 
 Several improvements have been made to the solvers.
 
@@ -174,7 +174,7 @@ f(x) = C₁ + C₂⋅erf⎜────⎟ + x
                   ⎝ 2  ⎠
 ```
 
-# Dropping Python 3.4 support
+## Dropping Python 3.4 support
 
 This is the last release of SymPy to support Python 3.4. SymPy 1.4 supports
 Python 2.7, 3.4, 3.5, 3.6, 3.7, and PyPy. What's perhaps more exciting is that
@@ -227,7 +227,7 @@ you do not do this. SymPy is also [already faster in Python
 due to things like `math.gcd` and `functools.lru_cache` being written in C,
 and general performance improvements in the interpreter itself.
 
-# And much more
+## And much more
 
 These are only a few of the highlights of the hundreds of changes in this
 release. The full release notes can be found on [our

--- a/apps/labs/posts/whats-next-for-pydatasparse.md
+++ b/apps/labs/posts/whats-next-for-pydatasparse.md
@@ -12,33 +12,38 @@ hero:
   imageAlt: 'An illustration of a brown hand holding up a microphone, with some graphical elements highlighting the top of the microphone.'
 ---
 
-# What have we been doing so far? 🤔
-## Research 📚
+## What have we been doing so far? 🤔
+
+### Research 📚
+
 A lot of behind the scenes work has been taking place on PyData/Sparse. Not so much in terms of code, more in terms of research and community/team building. I've more-or-less decided to use the structure and the research behind the [Tensor Algebra Compiler](https://github.com/tensor-compiler/taco), the work of Fredrik Kjolstad and his collaborators at MIT. 🙇🏻‍♂️ To this end, I've read/watched the following talks and papers:
 
-* Fredrik Kjolstad, Shoaib Kamil, Stephen Chou, David Lugato, and Saman Amarasinghe. 2017. The tensor algebra compiler. Proc. ACM Program. Lang. 1, OOPSLA, Article 77 (October 2017), 29 pages. DOI:[https://doi.org/10.1145/3133901](https://doi.org/10.1145/3133901)
-* Fredrik Kjolstad, Peter Ahrens, Shoaib Kamil, and Saman Amarasinghe. 2018. Sparse Tensor Algebra Optimizations with Workspaces. [https://arxiv.org/abs/1802.10574](https://arxiv.org/abs/1802.10574)
-* Chou, Stephen, Fredrik Kjolstad, and Saman Amarasinghe. “Format Abstraction for Sparse Tensor Algebra Compilers.” Proceedings of the ACM on Programming Languages 2.OOPSLA (2018): 1–30. Crossref. Web. [https://arxiv.org/abs/1804.10112](https://arxiv.org/abs/1804.10112)
-* Ryan Senanayake, Fredrik Kjolstad, Changwan Hong, Shoaib Kamil, and Saman Amarasinghe. 2019. A Unified Iteration Space Transformation Framework for Sparse and Dense Tensor Algebra [https://arxiv.org/abs/2001.00532](https://arxiv.org/abs/2001.00532)
-* Stephen Chou, Fredrik Kjolstad, Saman Amarasinghe. Automatic Generation of Efficient Sparse Tensor Format Conversion Routines. 2019. Automatic Generation of Efficient Sparse Tensor Format Conversion Routines [https://arxiv.org/abs/2001.02609](https://arxiv.org/abs/2001.02609)
-* The Sparse Tensor Algebra Compiler [https://www.youtube.com/watch?v=0OP8WjFyU-Q](https://www.youtube.com/watch?v=0OP8WjFyU-Q)
-* Format Abstraction for Sparse Tensor Algebra Compilers [https://www.youtube.com/watch?v=sQOq3Ci4tB0](https://www.youtube.com/watch?v=sQOq3Ci4tB0)
-* The Tensor Algebra Compiler [https://www.youtube.com/watch?v=yAtG64qV2nM](https://www.youtube.com/watch?v=yAtG64qV2nM)
+- Fredrik Kjolstad, Shoaib Kamil, Stephen Chou, David Lugato, and Saman Amarasinghe. 2017. The tensor algebra compiler. Proc. ACM Program. Lang. 1, OOPSLA, Article 77 (October 2017), 29 pages. DOI:[https://doi.org/10.1145/3133901](https://doi.org/10.1145/3133901)
+- Fredrik Kjolstad, Peter Ahrens, Shoaib Kamil, and Saman Amarasinghe. 2018. Sparse Tensor Algebra Optimizations with Workspaces. [https://arxiv.org/abs/1802.10574](https://arxiv.org/abs/1802.10574)
+- Chou, Stephen, Fredrik Kjolstad, and Saman Amarasinghe. “Format Abstraction for Sparse Tensor Algebra Compilers.” Proceedings of the ACM on Programming Languages 2.OOPSLA (2018): 1–30. Crossref. Web. [https://arxiv.org/abs/1804.10112](https://arxiv.org/abs/1804.10112)
+- Ryan Senanayake, Fredrik Kjolstad, Changwan Hong, Shoaib Kamil, and Saman Amarasinghe. 2019. A Unified Iteration Space Transformation Framework for Sparse and Dense Tensor Algebra [https://arxiv.org/abs/2001.00532](https://arxiv.org/abs/2001.00532)
+- Stephen Chou, Fredrik Kjolstad, Saman Amarasinghe. Automatic Generation of Efficient Sparse Tensor Format Conversion Routines. 2019. Automatic Generation of Efficient Sparse Tensor Format Conversion Routines [https://arxiv.org/abs/2001.02609](https://arxiv.org/abs/2001.02609)
+- The Sparse Tensor Algebra Compiler [https://www.youtube.com/watch?v=0OP8WjFyU-Q](https://www.youtube.com/watch?v=0OP8WjFyU-Q)
+- Format Abstraction for Sparse Tensor Algebra Compilers [https://www.youtube.com/watch?v=sQOq3Ci4tB0](https://www.youtube.com/watch?v=sQOq3Ci4tB0)
+- The Tensor Algebra Compiler [https://www.youtube.com/watch?v=yAtG64qV2nM](https://www.youtube.com/watch?v=yAtG64qV2nM)
 
 A bit heavy, so don't feel obliged to go through them. 😉
 
-## Resources 👥
+### Resources 👥
+
 I've also had conversations with Ralf Gommers about getting someone experienced in Computer Science on board, as a lot of this work is very heavy on Computer Science.
 
-## Strategy 🦾
+### Strategy 🦾
+
 The original TACO compiler requires a compiler at runtime, which isn't ideal for many users. However, what's nice is that we have Numba as a Python package. One, instead of emitting C code, can emit Python AST to be transpiled to LLVM by Numba, and then to machine code. I settled on this after researching Cppyy, which also requires a compiler, and pybind11, which wouldn't work as TACO itself is built to require a compiler.
 
 The above warrants some explanation as to _why_ exactly we're following this pattern. See, TACO is based on the fact that many popular matrix formats can be created using just a few per-dimension formats. The advantage behind this is that one can create highly efficient
 code from just a few building blocks (albeit some hard-to-understand ones) for a lot of different formats. The downside is, one needs to do some code generation (the original TACO emits C code). In Python-land, one could emit source code or AST, with the latter being easier to debug and with guaranteed syntatical correctness. This is the reason I decided to go with AST.
 
+## API Changes 👨🏻‍💻
 
-# API Changes 👨🏻‍💻
 I'd also like to invite anyone who's interested into the discussion about API changes. The discussion can be found in [this issue](https://github.com/pydata/sparse/issues/326), but essentially, ~~we're planning on moving to a lazy model for an asymptotically better runtime performance~~. We decided not to go and break backwards compatibility and essentially decided to have a separate submodule for this kind of work, then calling `.compute()` similar to Dask at the end.
 
-# So what does this mean for the user? 😕
+## So what does this mean for the user? 😕
+
 Why, support for a lot more operations across a lot more formats, really. 😄 And don't forget the performance. 🚀 With the downside being lazy operations a-la Dask.


### PR DESCRIPTION
See PR #873 for some context. 

Our blog post build code takes the blog title from the post metadata and renders it both in the HTML `<title>` tag as well as at the top of the page. For this reason, the body of the blog post markdown should not contain any level-1 headings, only level-2 and up. 

Most blog posts in the repo have been written this way, but there were a few exceptions that this PR attempts to correct.

Note: my editor also introduced a number of formatting and whitespace changes. If these add too much review burden, please let me know and I'll redo the PR so that it strictly only has heading changes.