### PR TITLE
FIX - make team member image container inline-flex

### DIFF
--- a/libs/shared/ui-components/src/Team/TeamMember/TeamMemberImage.tsx
+++ b/libs/shared/ui-components/src/Team/TeamMember/TeamMemberImage.tsx
@@ -11,7 +11,7 @@ export type TTeamMemberImage = {
 };
 
 export const TeamMemberImage: FC<TTeamMemberImage> = ({ image, shape }) => (
-  <div className="flex relative mb-[0.5rem] md:mb-[1rem]">
+  <div className="inline-flex relative mb-[0.5rem] md:mb-[1rem]">
     <Picture
       className="brightness-110 grayscale"
       imageSrc={image.filename}


### PR DESCRIPTION
@agriyakhetarpal reported in Slack:

> Hi! I noticed a minor issue on the Labs team page (please see attached screenshot), where there's an empty pastel lavender coloured bar on the right of everyone's photos for "page width (px)" ∀ [1185, 1280). I could propose a fix for the CSS myself, but AFAIK, we don't have this page in specific open-sourced.
> <image src="https://github.com/user-attachments/assets/6d0f5812-c12c-42ed-8def-3444d4f7fd28" alt="" width="400"/>

This small change seems to do the trick. 