### PR TITLE
Small fixes for 2024 report blog post

### DIFF
--- a/apps/labs/posts/labs-annual-report-2024.md
+++ b/apps/labs/posts/labs-annual-report-2024.md
@@ -130,7 +130,7 @@ The following graphic presents notable highlights from the report.
 
   <section>
     <h3>Contact Us</h3>
-    <p>Visit <a href="https://labs.quansight.org">labs.quansight.org</a> to learn more about us, and reach out at <a href="mailto:connect@quansight.com">connect@quansight.com</a>.</p>
+    <p>Visit <a href="https://labs.quansight.org">labs.quansight.org</a> to learn more about us, and reach out at connect@quansight.com.</p>
     <p>Follow us:</p>
     <ul>
       <li><a href="https://bsky.app/profile/quansight.com">Bluesky</a></li>

--- a/apps/labs/posts/labs-annual-report-2024.md
+++ b/apps/labs/posts/labs-annual-report-2024.md
@@ -33,7 +33,7 @@ The following graphic presents notable highlights from the report.
   />
 </p>
 
-<div class="sr-only">
+<div className="sr-only">
   <h2>At a Glance: Quansight Labs Annual Report 2024</h2>
 
   <section>


### PR DESCRIPTION
This fixes a couple small issues with the blog post for the 2024 annual report:

- In React, the attribute should be `className` not `class`.
- Our framework automatically linkifies emails, and since we were manually linking the email, this meant that it was linked twice