### PR TITLE
Linkify and lock size of infographic (2024 annual report)

### DIFF
--- a/apps/labs/posts/labs-annual-report-2024.md
+++ b/apps/labs/posts/labs-annual-report-2024.md
@@ -142,7 +142,7 @@ The following graphic presents notable highlights from the report.
 
   <section>
     <h3>Contact Us</h3>
-    <p>Visit <a href="https://labs.quansight.org">labs.quansight.org</a> to learn more about us, and reach out at connect@quansight.com</p>
+    <p>Visit <a href="https://labs.quansight.org">labs.quansight.org</a> to learn more about us, and reach out at <a href="mailto:connect@quansight.com">connect@quansight.com</a>.</p>
     <p>Follow us:</p>
     <ul>
       <li><a href="https://bsky.app/profile/quansight.com">Bluesky</a></li>

--- a/apps/labs/posts/labs-annual-report-2024.md
+++ b/apps/labs/posts/labs-annual-report-2024.md
@@ -27,9 +27,21 @@ Our annual report offers an in-depth look at our work over the past year, coveri
 The following graphic presents notable highlights from the report.
 
 <p align="center">
+  <map name="infographic">
+    {/* These image map links are aria-hidden because they are repeated in the sr-only div below */}
+    <area aria-hidden="true" shape="rect" coords="115,3028,235,3053" href="https://labs.quansight.com" target="_blank" />
+    <area aria-hidden="true" shape="rect" coords="521,3028,682,3053" href="mailto:connect@quansight.com" />
+    <area aria-hidden="true" shape="rect" coords="80,3078,362,3105" href="https://bsky.app/profile/quansight.com" target="_blank" />
+    <area aria-hidden="true" shape="rect" coords="80,3112,205,3137" href="https://x.com/quansightai" target="_blank" />
+    <area aria-hidden="true" shape="rect" coords="80,3147,410,3175" href="https://www.linkedin.com/company/quansight" target="_blank" />
+  </map>
   <img
     src="/posts/labs-annual-report-2024/infographic.png"
     alt=""
+    useMap="#infographic"
+    width="896"
+    height="3545"
+    style={{maxWidth: "896px"}}
   />
 </p>
 
@@ -130,7 +142,7 @@ The following graphic presents notable highlights from the report.
 
   <section>
     <h3>Contact Us</h3>
-    <p>Visit <a href="https://labs.quansight.org">labs.quansight.org</a> to learn more about us, and reach out at <a href="mailto:connect@quansight.com">connect@quansight.com</a>.</p>
+    <p>Visit <a href="https://labs.quansight.org">labs.quansight.org</a> to learn more about us, and reach out at connect@quansight.com</p>
     <p>Follow us:</p>
     <ul>
       <li><a href="https://bsky.app/profile/quansight.com">Bluesky</a></li>


### PR DESCRIPTION
This PR fixes a two different issues with the infographic

1. Links in graphic not clickable
2. Infographic too small on mobile (see screenshot below)

To fix both of these issues, this PR:

1. Adds an image map
2. Locks the width and height of the image (also necessary for the image map)

Yes, this means that the user has to scroll if the screen is too narrow (less than about 900px). However, some considerations:

1. On mobile, the user already has to pinch zoom and then scroll horizontally for the infographic to be readable
2. On tablets, the user can reorient to landscape instead of portrait and then the infographic will likely fit
3. Most desktop screens are greater than 900px, so there shouldn't be any problem on desktop.

One thing I did not do was actually resize the PNG file itself. I figured that if somebody wanted to download the image and/or print it, it would be better if they have the full resolution.


<img src="https://github.com/user-attachments/assets/148aa792-0ef1-47e4-9f87-bd9996069509" alt="mobile screenshot" width="327" height="708" />
