### PR TITLE
add note about node 25 not working to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ System requirements:
 
 - [Node.js](https://nodejs.org)
 
+Note that the site is currently incompatible with Node 25, so use
+node 24. On homebrew you can install it with `brew install node@24`.
+
 Copy and paste the following commands:
 
 ```sh


### PR DESCRIPTION
While working on #948 I had trouble building the blog locally. Under node 25 I see the following error:

```
± npm run start:labs

> quansight@0.0.0 start:labs
> nx serve labs


> nx run labs:serve

info  - Loaded env from apps/labs/.env
warn  - Invalid next.config.js options detected:
  - The root value has an unexpected property, nx, which is not in the list of allowed properties (amp, analyticsId, assetPrefix, basePath, cleanDistDir, compiler, compress, crossOrigin, devIndicators, distDir, env, eslint, excludeDefaultMomentLocales, experimental, exportPathMap, future, generateBuildId, generateEtags, headers, httpAgentOptions, i18n, images, onDemandEntries, optimizeFonts, output, outputFileTracing, pageExtensions, poweredByHeader, productionBrowserSourceMaps, publicRuntimeConfig, reactStrictMode, redirects, rewrites, sassOptions, serverRuntimeConfig, staticPageGenerationTimeout, swcMinify, trailingSlash, typescript, useFileSystemPublicRoutes, webpack).

See more info here: https://nextjs.org/docs/messages/invalid-next-config
Cannot read properties of undefined (reading 'prototype')

 ——————————————————————————————————————————————————————————————————————————————

 >  NX   Running target "labs:serve" failed

   Failed tasks:

   - labs:serve

   Hint: run the command with --verbose for more details.
```

Downgrading to node 24 lets me launch the site app.