### PR TITLE
Fix eslint error and warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,7 @@
         "prettier"
       ],
       "rules": {
-        "@typescript-eslint/ban-ts-comment": ["off"],
+        "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/ban-ts-ignore": ["off"],
         "@typescript-eslint/ban-types": [
           "error",
@@ -60,8 +60,8 @@
             }
           }
         ],
-        "@typescript-eslint/explicit-function-return-type": ["off"],
-        "@typescript-eslint/indent": ["off"],
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/indent": "off",
         "@typescript-eslint/naming-convention": [
           "error",
           {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,8 +72,8 @@
         "@typescript-eslint/no-shadow": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/prefer-interface": ["off"],
-        "@typescript-eslint/no-explicit-any": ["error"],
-        "@typescript-eslint/explicit-module-boundary-types": ["off"],
+        "@typescript-eslint/no-explicit-any": "error",
+        "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/default-param-last": ["off"],
         "no-multiple-empty-lines": "error",
         "import/order": [

--- a/apps/labs/services/posts/serializePost.ts
+++ b/apps/labs/services/posts/serializePost.ts
@@ -14,8 +14,8 @@ import { TeamQuery } from '../../api';
 import { TPost, TPostAuthor } from '../../types/storyblok/bloks/posts';
 import { getFileContent } from '../api/posts/getFileContent';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const serializePostMeta = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: Record<string, any>,
   authors: Array<ArrayElementType<TeamQuery['PersonItems']['items']>> = [],
 ): TPost['meta'] => {
@@ -47,8 +47,8 @@ export const serializePostMeta = (
   };
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const serializePostContent = async (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: Record<string, any>,
   content: string,
 ): Promise<MDXRemoteSerializeResult<Record<string, unknown>>> => {


### PR DESCRIPTION
Fix local linting errors and warnings.

1. Error:

```
.../Quansight-website/apps/labs/services/posts/serializePost.ts
  19:24  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  52:24  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 2 problems (2 errors, 0 warnings)

Lint errors found in the listed files.
```

Move the ignore statement to the appropriate line to fix.

2. Warning: "Array has too few items. Expected 2 or more.", use string instead of array to fix.