### PR TITLE
Migrate from next/legacy/image to next/image

### DIFF
--- a/apps/consulting/types/storyblok/bloks/hero.ts
+++ b/apps/consulting/types/storyblok/bloks/hero.ts
@@ -1,9 +1,8 @@
-import { ImageProps } from 'next/legacy/image';
-
 import { TImage, TBlok } from '@quansight/shared/types';
 import {
   HeroVariant,
   HeroBackgroundVariant,
+  TObjectFit,
 } from '@quansight/shared/ui-components';
 
 import { ComponentType } from '../../../components/BlokProvider/types';
@@ -14,12 +13,12 @@ export type THeroRawData = {
   variant: HeroVariant;
   subTitle?: string;
   component: ComponentType.Hero;
-  objectFit?: ImageProps['objectFit'];
+  objectFit?: TObjectFit;
   backgroundColor?: HeroBackgroundVariant;
   imageMobile?: TImage;
-  objectFitMobile?: ImageProps['objectFit'];
+  objectFitMobile?: TObjectFit;
   imageTablet?: TImage;
-  objectFitTablet?: ImageProps['objectFit'];
+  objectFitTablet?: TObjectFit;
   imageDesktop?: TImage;
-  objectFitDesktop?: ImageProps['objectFit'];
+  objectFitDesktop?: TObjectFit;
 } & TBlok;

--- a/apps/labs/components/LinkWithArrow/LinkWithArrow.tsx
+++ b/apps/labs/components/LinkWithArrow/LinkWithArrow.tsx
@@ -1,6 +1,6 @@
 import React, { FC, PropsWithChildren } from 'react';
 
-import Image from 'next/legacy/image';
+import Image from 'next/image';
 import Link, { LinkProps } from 'next/link';
 
 export type LinkWithArrowProps = PropsWithChildren<LinkProps>;

--- a/apps/labs/types/storyblok/bloks/hero.ts
+++ b/apps/labs/types/storyblok/bloks/hero.ts
@@ -1,9 +1,8 @@
-import { ImageProps } from 'next/legacy/image';
-
 import { TImage, TBlok } from '@quansight/shared/types';
 import {
   HeroVariant,
   HeroBackgroundVariant,
+  TObjectFit,
 } from '@quansight/shared/ui-components';
 
 import { ComponentType } from '../../../components/BlokProvider/types';
@@ -14,12 +13,12 @@ export type THeroRawData = {
   variant: HeroVariant;
   subTitle?: string;
   component: ComponentType.Hero;
-  objectFit?: ImageProps['objectFit'];
+  objectFit?: TObjectFit;
   backgroundColor?: HeroBackgroundVariant;
   imageMobile?: TImage;
-  objectFitMobile?: ImageProps['objectFit'];
+  objectFitMobile?: TObjectFit;
   imageTablet?: TImage;
-  objectFitTablet?: ImageProps['objectFit'];
+  objectFitTablet?: TObjectFit;
   imageDesktop?: TImage;
-  objectFitDesktop?: ImageProps['objectFit'];
+  objectFitDesktop?: TObjectFit;
 } & TBlok;

--- a/libs/shared/ui-components/src/Hero/Hero.tsx
+++ b/libs/shared/ui-components/src/Hero/Hero.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 
 import clsx from 'clsx';
-import Image from 'next/legacy/image';
+import Image from 'next/image';
 
 import { HeroResponsiveImages } from './HeroResponsiveImages';
 import { THeroProps, HeroVariant, HeroBackgroundVariant } from './types';
@@ -52,10 +52,12 @@ export const Hero: FC<THeroProps> = ({
         ) : imageSrc ? (
           <Image
             src={imageSrc}
-            alt={imageAlt}
-            layout="fill"
-            objectFit={objectFit || 'cover'}
-            objectPosition="center"
+            alt={imageAlt || ''}
+            fill
+            style={{
+              objectFit: objectFit || 'cover',
+              objectPosition: 'center',
+            }}
           />
         ) : null}
         {title && (

--- a/libs/shared/ui-components/src/Hero/HeroResponsiveImages.tsx
+++ b/libs/shared/ui-components/src/Hero/HeroResponsiveImages.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/legacy/image';
+import Image from 'next/image';
 
 import { useDeviceSize, DeviceSizeVariant } from '@quansight/shared/utils';
 
@@ -17,9 +17,11 @@ export const HeroResponsiveImages = ({
         <Image
           src={imageMobile.imageSrc}
           alt={imageMobile.imageAlt}
-          layout="fill"
-          objectFit={imageMobile.objectFit || 'cover'}
-          objectPosition="center"
+          fill
+          style={{
+            objectFit: imageMobile.objectFit || 'cover',
+            objectPosition: 'center',
+          }}
         />
       )}
       {(deviceSize === DeviceSizeVariant.Tablet ||
@@ -27,18 +29,22 @@ export const HeroResponsiveImages = ({
         <Image
           src={imageTablet.imageSrc}
           alt={imageTablet.imageAlt}
-          layout="fill"
-          objectFit={imageTablet.objectFit || 'cover'}
-          objectPosition="center"
+          fill
+          style={{
+            objectFit: imageTablet.objectFit || 'cover',
+            objectPosition: 'center',
+          }}
         />
       )}
       {deviceSize === DeviceSizeVariant.Desktop && (
         <Image
           src={imageDesktop.imageSrc}
           alt={imageDesktop.imageAlt}
-          layout="fill"
-          objectFit={imageDesktop.objectFit || 'cover'}
-          objectPosition="center"
+          fill
+          style={{
+            objectFit: imageDesktop.objectFit || 'cover',
+            objectPosition: 'center',
+          }}
         />
       )}
     </>

--- a/libs/shared/ui-components/src/Hero/types.ts
+++ b/libs/shared/ui-components/src/Hero/types.ts
@@ -1,4 +1,4 @@
-import { ImageProps } from 'next/legacy/image';
+import { TObjectFit } from '../Picture/types';
 
 export enum HeroVariant {
   Small = 'small',
@@ -16,7 +16,7 @@ export enum HeroBackgroundVariant {
 export type TCustomImage = {
   imageSrc: string;
   imageAlt: string;
-  objectFit: ImageProps['objectFit'];
+  objectFit: TObjectFit;
 };
 
 export type TResponsiveImages = {
@@ -32,7 +32,7 @@ export type THeroProps = {
   imageSrc?: string;
   imageAlt?: string;
   backgroundColor?: string;
-  objectFit?: ImageProps['objectFit'];
+  objectFit?: TObjectFit;
   imageMobile?: TCustomImage;
   imageTablet?: TCustomImage;
   imageDesktop?: TCustomImage;

--- a/libs/shared/ui-components/src/Picture/Picture.tsx
+++ b/libs/shared/ui-components/src/Picture/Picture.tsx
@@ -1,13 +1,71 @@
-import { FC } from 'react';
+import { CSSProperties, FC } from 'react';
 
-import Image from 'next/legacy/image';
+import Image from 'next/image';
 
 import { TPictureProps } from './types';
 
 export const Picture: FC<TPictureProps> = ({
   imageSrc,
   imageAlt,
-  ...props
-}) => <Image src={imageSrc} alt={imageAlt} {...props} />;
+  width,
+  height,
+  layout,
+  objectFit,
+  objectPosition,
+  priority,
+  onLoadingComplete,
+  className,
+}) => {
+  const objectStyle: CSSProperties = {};
+  if (objectFit) objectStyle.objectFit = objectFit;
+  if (objectPosition) objectStyle.objectPosition = objectPosition;
+
+  if (layout === 'fill') {
+    return (
+      <Image
+        src={imageSrc}
+        alt={imageAlt}
+        fill
+        priority={priority}
+        onLoadingComplete={onLoadingComplete}
+        className={className}
+        style={objectStyle}
+      />
+    );
+  }
+
+  const numericWidth = typeof width === 'string' ? parseInt(width, 10) : width;
+  const numericHeight =
+    typeof height === 'string' ? parseInt(height, 10) : height;
+
+  let style: CSSProperties = objectStyle;
+  if (layout === 'responsive') {
+    style = { ...objectStyle, width: '100%', height: 'auto' };
+  } else if (layout === 'fixed' && numericWidth && numericHeight) {
+    style = {
+      ...objectStyle,
+      width: `${numericWidth}px`,
+      height: `${numericHeight}px`,
+    };
+  } else if (numericWidth && numericHeight) {
+    style = {
+      ...objectStyle,
+      aspectRatio: `${numericWidth} / ${numericHeight}`,
+    };
+  }
+
+  return (
+    <Image
+      src={imageSrc}
+      alt={imageAlt}
+      width={numericWidth}
+      height={numericHeight}
+      priority={priority}
+      onLoadingComplete={onLoadingComplete}
+      className={className}
+      style={Object.keys(style).length ? style : undefined}
+    />
+  );
+};
 
 export default Picture;

--- a/libs/shared/ui-components/src/Picture/types.ts
+++ b/libs/shared/ui-components/src/Picture/types.ts
@@ -1,14 +1,16 @@
-import { ImageProps } from 'next/legacy/image';
+export type TObjectFit = 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
+
+export type TPictureLayout = 'fill' | 'responsive' | 'intrinsic' | 'fixed';
 
 export type TPictureProps = {
   imageSrc: string;
   imageAlt: string;
-  width?: ImageProps['width'];
-  height?: ImageProps['height'];
-  layout?: ImageProps['layout'];
-  objectFit?: ImageProps['objectFit'];
-  objectPosition?: ImageProps['objectPosition'];
-  priority?: ImageProps['priority'];
-  onLoadingComplete?: ImageProps['onLoadingComplete'];
+  width?: number | string;
+  height?: number | string;
+  layout?: TPictureLayout;
+  objectFit?: TObjectFit;
+  objectPosition?: string;
+  priority?: boolean;
+  onLoadingComplete?: (img: HTMLImageElement) => void;
   className?: string;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9137,7 +9137,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9177,7 +9176,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9198,7 +9196,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9219,7 +9216,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9240,7 +9236,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9261,7 +9256,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9282,7 +9276,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9303,7 +9296,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9324,7 +9316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9345,7 +9336,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9366,7 +9356,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9387,7 +9376,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9408,7 +9396,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9429,7 +9416,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9447,7 +9433,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -26553,7 +26538,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -35120,7 +35104,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
Replaces all `next/legacy/image` imports with the modern `next/image`
across both apps and the shared UI library. The Picture wrapper keeps
its existing API (layout/objectFit/objectPosition) and translates legacy
props internally, so all 30+ call sites remain unchanged. `Hero`,
`HeroResponsiveImages`, and `LinkWithArrow` are converted directly.

In the default (intrinsic) branch of Picture, an explicit CSS
`aspect-ratio` is set to preserve the legacy behavior where e.g. team images
always render at exactly 200x200 regardless of source dimensions.

Generated-by: Claude Opus 4.7