### PR TITLE
add social media tags

### DIFF
--- a/apps/labs/astro.config.mjs
+++ b/apps/labs/astro.config.mjs
@@ -4,7 +4,20 @@ import react from '@astrojs/react';
 import rehypeKatex from 'rehype-katex';
 import remarkMath from 'remark-math';
 
+// `site` is what BaseLayout builds absolute og:url/og:image from. On a
+// Vercel preview build, point it at that deployment so the tags describe
+// the preview being tested rather than production; VERCEL_BRANCH_URL is
+// the stable per-branch host (labs-git-<branch>-quansight.vercel.app),
+// VERCEL_URL the per-deployment one. Production always keeps the real
+// domain, as does a local build (neither variable is set).
+const previewHost = process.env.VERCEL_BRANCH_URL || process.env.VERCEL_URL;
+const site =
+  process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production' && previewHost
+    ? `https://${previewHost}`
+    : 'https://labs.quansight.org';
+
 export default defineConfig({
+  site,
   output: 'static',
   integrations: [
     react(),

--- a/apps/labs/src/layouts/BaseLayout.astro
+++ b/apps/labs/src/layouts/BaseLayout.astro
@@ -6,9 +6,20 @@ import SiteFooter from '../components/SiteFooter.astro';
 interface Props {
   title?: string;
   description?: string;
+  image?: string;
 }
 
-const { title = 'Quansight Labs', description = '' } = Astro.props;
+const {
+  title = 'Quansight Labs',
+  description = '',
+  image = '/images/logos/labs-logo-footer-desktop.png',
+} = Astro.props;
+
+const siteUrl = (
+  Astro.site?.toString() ?? 'https://labs.quansight.org'
+).replace(/\/$/, '');
+const canonicalUrl = `${siteUrl}${Astro.url.pathname}`;
+const imageUrl = image.startsWith('http') ? image : `${siteUrl}${image}`;
 ---
 
 <!doctype html>
@@ -18,6 +29,18 @@ const { title = 'Quansight Labs', description = '' } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <title>{title}</title>
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:image" content={imageUrl} />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={imageUrl} />
+
     <link rel="icon" href="/favicon.png" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400;600;700;800&family=Mukta:wght@400;500;700;800&family=Fira+Code:wght@500&display=swap"

--- a/apps/labs/src/layouts/BaseLayout.astro
+++ b/apps/labs/src/layouts/BaseLayout.astro
@@ -12,7 +12,12 @@ interface Props {
 const {
   title = 'Quansight Labs',
   description = '',
-  image = '/images/logos/labs-logo-footer-desktop.png',
+  // Social cards need an opaque image at roughly 1.91:1 and at least
+  // 300x157 (Twitter's summary_large_image minimum). The footer logo is
+  // 239x66 and 91% transparent white artwork meant for the dark footer, so
+  // platforms either flattened it onto white -- invisible -- or declined to
+  // render a card image at all.
+  image = '/images/blog_feature_var2.png',
 } = Astro.props;
 
 const siteUrl = (

--- a/apps/labs/src/templates/BlogPost.astro
+++ b/apps/labs/src/templates/BlogPost.astro
@@ -37,6 +37,7 @@ const authors = post.data.authors.map((s) => {
 <BaseLayout
   title={`${post.data.title} | Quansight Labs`}
   description={post.data.description}
+  image={post.data.featuredImage?.src}
 >
   {post.data.hero?.imageSrc && (
     <Hero


### PR DESCRIPTION
Related to #982, which changed when the site moved away from storyblock in #980. Add social media tags so pasting a blog post into social media will show an image and a blurb.