### PR TITLE
Remove Labs vercel.json

### DIFF
--- a/apps/labs/pages/home.yml
+++ b/apps/labs/pages/home.yml
@@ -18,7 +18,7 @@ blocks:
     and open source projects and communities they rely on.
   rightColumn: We are a team of developers, community leads, designers, and writers. Together we create,
     contribute to, and maintain open source technology for research and data science workflows. We help
-    our customers to safely and effectively build technTology on open source to drive their own innovation,
+    our customers to safely and effectively build technology on open source to drive their own innovation,
     while ensuring their involvement strengthens the project's community and long-term health.
   final: |-
     Formerly, we were Quansight Labs, the public benefit division of Quansight LLC. In 2025, Quansight Labs evolved into Quansight, Public Benefit Corporation.

--- a/site-admin.md
+++ b/site-admin.md
@@ -2,21 +2,22 @@
 
 Guide for site changes that are **not** [blog posts](how-to-publish-a-new-blog-post.md).
 
-- [Running the website locally](#running-the-website-locally)
-- [Orientation](#orientation)
-- [Deployment](#deployment)
-- [Content changes](#content-changes)
-  - [Adding or editing a team member](#adding-or-editing-a-team-member)
-  - [Adding or editing a page](#adding-or-editing-a-page)
-  - [Editing the header or footer](#editing-the-header-or-footer)
-  - [Editing the projects list](#editing-the-projects-list)
-- [Code changes](#code-changes)
-  - [Adding a new block component](#adding-a-new-block-component)
-  - [Hero images](#hero-images)
-- [Integrations](#integrations)
-  - [GitHub](#github)
-  - [Vercel](#vercel)
-  - [Slack](#slack)
+- [Site admin](#site-admin)
+  - [Running the website locally](#running-the-website-locally)
+  - [Orientation](#orientation)
+  - [Deployment](#deployment)
+  - [Content changes](#content-changes)
+    - [Adding or editing a team member](#adding-or-editing-a-team-member)
+    - [Adding or editing a page](#adding-or-editing-a-page)
+    - [Editing the header or footer](#editing-the-header-or-footer)
+    - [Editing the projects list](#editing-the-projects-list)
+  - [Code changes](#code-changes)
+    - [Adding a new block component](#adding-a-new-block-component)
+    - [Hero images](#hero-images)
+  - [Integrations](#integrations)
+    - [GitHub](#github)
+    - [Vercel](#vercel)
+    - [Slack](#slack)
 
 ## Running the website locally
 
@@ -215,9 +216,11 @@ URL on every pull request and deploys to production when commits land on `main`.
 
 ### Vercel
 
-The Labs site corresponds to the `quansight-labs` project in Vercel. Build
-configuration is in `vercel.json` at the repo root — it points Vercel at
-`apps/labs/` and runs `npm run build` there.
+The Labs site corresponds to the `quansight-labs` project in Vercel.
+The deployment configuration is set directly in the Vercel dashboard:
+
+- `apps/labs` is the root directory for the project, deployment will be skipped
+  when there are no changes to the root directory.
 
 ### Slack
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,0 @@
-{
-  "framework": null,
-  "installCommand": "cd apps/labs && npm install",
-  "buildCommand": "cd apps/labs && npm run build",
-  "outputDirectory": "apps/labs/dist"
-}


### PR DESCRIPTION
This is a prerequisite for #999.

Currently, we have a `vercel.json` file at the top of the repository. This is used as the default project configuration, overriding any configuration set at the app level or in the Vercel dashboard (which is currently causing the "consulting" deployment to fail).

For now, I have removed the configuration file and kept the deployment configuration in the Vercel dashboard. If we need more complex configurations than the deployment build, we can add a new `vercel.json` in the `apps/labs` directory.